### PR TITLE
✨ Allow options to be updated on the `MarkdownIt` instance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ from markdown_it.token import Token
 from mdformat.renderer import MDRenderer
 
 
-def update_mdit(mdit: MarkdownIt, env: Optional[dict] = None) -> None:
+def update_mdit(mdit: MarkdownIt) -> None:
    """Update the parser, e.g. by adding a plugin: `mdit.use(myplugin)`"""
    pass
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ from markdown_it.token import Token
 from mdformat.renderer import MDRenderer
 
 
-def update_mdit(mdit: MarkdownIt) -> None:
+def update_mdit(mdit: MarkdownIt, env: Optional[dict] = None) -> None:
    """Update the parser, e.g. by adding a plugin: `mdit.use(myplugin)`"""
    pass
 

--- a/mdformat/_api.py
+++ b/mdformat/_api.py
@@ -18,7 +18,7 @@ def text(
     markdown_it = MarkdownIt(renderer_cls=MDRenderer)
     # store reference labels in link/image tokens
     markdown_it.options["store_labels"] = True
-    markdown_it.options["mdformat"] = options
+    markdown_it.options["mdformat"] = options or {}
 
     markdown_it.options["parser_extension"] = []
     for name in extensions:

--- a/mdformat/_api.py
+++ b/mdformat/_api.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import Iterable, Optional, Union
 
 from markdown_it import MarkdownIt
-from markdown_it.utils import AttrDict
 
 import mdformat.plugins
 from mdformat.renderer import MDRenderer
@@ -11,7 +10,7 @@ from mdformat.renderer import MDRenderer
 def text(
     md: str,
     *,
-    env: Optional[dict] = None,
+    options: Optional[dict] = None,
     extensions: Iterable[str] = (),
     codeformatters: Iterable[str] = (),
 ) -> str:
@@ -19,23 +18,24 @@ def text(
     markdown_it = MarkdownIt(renderer_cls=MDRenderer)
     # store reference labels in link/image tokens
     markdown_it.options["store_labels"] = True
+    markdown_it.options.update(options or {})
 
     markdown_it.options["parser_extension"] = []
     for name in extensions:
         plugin = mdformat.plugins.PARSER_EXTENSIONS[name]
-        plugin.update_mdit(markdown_it, env)
+        plugin.update_mdit(markdown_it)
         markdown_it.options["parser_extension"].append(plugin)
     markdown_it.options["codeformatters"] = {
         lang: mdformat.plugins.CODEFORMATTERS[lang] for lang in codeformatters
     }
-    env = env if env is None else AttrDict(env)
-    return markdown_it.render(md, env=env)
+
+    return markdown_it.render(md)
 
 
 def file(
     f: Union[str, Path],
     *,
-    env: Optional[dict] = None,
+    options: Optional[dict] = None,
     extensions: Iterable[str] = (),
     codeformatters: Iterable[str] = (),
 ) -> None:
@@ -50,6 +50,9 @@ def file(
         raise ValueError(f'Can not format "{f}". It is not a file.')
     original_md = f.read_text(encoding="utf-8")
     formatted_md = text(
-        original_md, env=env, extensions=extensions, codeformatters=codeformatters
+        original_md,
+        options=options,
+        extensions=extensions,
+        codeformatters=codeformatters,
     )
     f.write_text(formatted_md, encoding="utf-8")

--- a/mdformat/_api.py
+++ b/mdformat/_api.py
@@ -28,7 +28,6 @@ def text(
     markdown_it.options["codeformatters"] = {
         lang: mdformat.plugins.CODEFORMATTERS[lang] for lang in codeformatters
     }
-
     return markdown_it.render(md)
 
 

--- a/mdformat/_api.py
+++ b/mdformat/_api.py
@@ -18,7 +18,7 @@ def text(
     markdown_it = MarkdownIt(renderer_cls=MDRenderer)
     # store reference labels in link/image tokens
     markdown_it.options["store_labels"] = True
-    markdown_it.options.update(options or {})
+    markdown_it.options["mdformat"] = options
 
     markdown_it.options["parser_extension"] = []
     for name in extensions:

--- a/mdformat/_cli.py
+++ b/mdformat/_cli.py
@@ -18,12 +18,12 @@ def run(cli_args: Sequence[str]) -> int:  # noqa: C901
         "--check", action="store_true", help="Do not apply changes to files"
     )
     parser.add_argument(
-        "-e",
-        dest="env",
+        "-o",
+        dest="options",
         metavar="key=value",
         default=[],
         action="append",
-        help="Pass env key:value to the renderer",
+        help="Set key:value options on the parser",
     )
     args = parser.parse_args(cli_args)
 
@@ -37,18 +37,18 @@ def run(cli_args: Sequence[str]) -> int:  # noqa: C901
         parser.error(f'File "{e.path}" does not exist.\n')
 
     # convert env args to dict
-    env = {}
-    for val in args.env:
+    options = {}
+    for val in args.options:
         try:
             key, val = val.split("=", 1)
         except ValueError:
-            parser.error("-e option must be in the form key=value")
+            parser.error("-o option must be in the form key=value")
         try:
             # if possible, safely evaluate string to data type
             val = literal_eval(val)
         except ValueError:
             pass
-        env[key] = val
+        options[key] = val
 
     # Enable all parser plugins
     enabled_parserplugins = mdformat.plugins.PARSER_EXTENSIONS.keys()
@@ -65,7 +65,7 @@ def run(cli_args: Sequence[str]) -> int:  # noqa: C901
             original_str = sys.stdin.read()
         formatted_str = mdformat.text(
             original_str,
-            env=env,
+            options=options,
             extensions=enabled_parserplugins,
             codeformatters=enabled_codeformatter_langs,
         )

--- a/mdformat/_cli.py
+++ b/mdformat/_cli.py
@@ -29,10 +29,10 @@ def run(cli_args: Sequence[str]) -> int:  # noqa: C901
     try:
         file_paths = resolve_file_paths(args.paths)
     except InvalidPath as e:
-        parser.error(f'File "{e.path}" does not exist.\n')
+        parser.error(f'File "{e.path}" does not exist.')
 
     # convert args to dict
-    options = dict(args._get_kwargs())
+    options = vars(args)
     options.pop("paths")
     # Enable all parser plugins
     enabled_parserplugins = mdformat.plugins.PARSER_EXTENSIONS.keys()

--- a/mdformat/_cli.py
+++ b/mdformat/_cli.py
@@ -36,7 +36,7 @@ def run(cli_args: Sequence[str]) -> int:  # noqa: C901
     except InvalidPath as e:
         parser.error(f'File "{e.path}" does not exist.\n')
 
-    # convert env args to dict
+    # convert args.options to dict
     options = {}
     for val in args.options:
         try:

--- a/mdformat/_cli.py
+++ b/mdformat/_cli.py
@@ -33,7 +33,6 @@ def run(cli_args: Sequence[str]) -> int:  # noqa: C901
 
     # convert args to dict
     options = vars(args)
-    options.pop("paths")
     # Enable all parser plugins
     enabled_parserplugins = mdformat.plugins.PARSER_EXTENSIONS.keys()
     # Enable code formatting for all languages that have a plugin installed

--- a/mdformat/_util.py
+++ b/mdformat/_util.py
@@ -3,19 +3,33 @@ from typing import Iterable
 
 from markdown_it import MarkdownIt
 
+import mdformat.plugins
 
-def is_md_equal(md1: str, md2: str, *, ignore_codeclasses: Iterable[str] = ()) -> bool:
+
+def is_md_equal(
+    md1: str,
+    md2: str,
+    options: dict,
+    *,
+    extensions: Iterable[str] = (),
+    codeformatters: Iterable[str] = (),
+) -> bool:
     """Check if two Markdown produce the same HTML.
 
     Renders HTML from both Markdown strings, strips whitespace and
     checks equality. Note that this is not a perfect solution, as there
     can be meaningful whitespace in HTML, e.g. in a <code> block.
     """
-    html1 = MarkdownIt().render(md1)
-    html2 = MarkdownIt().render(md2)
-    html1 = re.sub(r"\s+", "", html1)
-    html2 = re.sub(r"\s+", "", html2)
-    for codeclass in ignore_codeclasses:
-        html1 = re.sub(rf'<codeclass="language-{codeclass}">.*</pre>', "", html1)
-        html2 = re.sub(rf'<codeclass="language-{codeclass}">.*</pre>', "", html2)
-    return html1 == html2
+    html_texts = {}
+    mdit = MarkdownIt()
+    mdit.options["mdformat"] = options
+    for extension in extensions:
+        mdformat.plugins.PARSER_EXTENSIONS[extension].update_mdit(mdit)
+    for key, text in [("md1", md1), ("md2", md2)]:
+        html = mdit.render(text)
+        html = re.sub(r"\s+", "", html)
+        for codeclass in codeformatters:
+            html = re.sub(rf'<codeclass="language-{codeclass}">.*</pre>', "", html)
+        html_texts[key] = html
+
+    return html_texts["md1"] == html_texts["md2"]

--- a/mdformat/plugins.py
+++ b/mdformat/plugins.py
@@ -1,3 +1,4 @@
+import argparse
 import sys
 from typing import Callable, Dict, List, Mapping, Optional, Tuple
 
@@ -26,6 +27,11 @@ CODEFORMATTERS: Mapping[str, Callable[[str, str], str]] = _load_codeformatters()
 
 class ParserExtensionInterface(Protocol):
     """A interface for parser extension plugins."""
+
+    def add_cli_options(self, parser: argparse.ArgumentParser) -> None:
+        """Add options to the mdformat CLI, to be stored in
+        mdit.options["mdformat"]"""
+        pass
 
     def update_mdit(self, mdit: MarkdownIt) -> None:
         """Update the parser, e.g. by adding a plugin: `mdit.use(myplugin)`"""

--- a/mdformat/plugins.py
+++ b/mdformat/plugins.py
@@ -30,12 +30,10 @@ class ParserExtensionInterface(Protocol):
 
     def add_cli_options(self, parser: argparse.ArgumentParser) -> None:
         """Add options to the mdformat CLI, to be stored in
-        mdit.options["mdformat"]"""
-        pass
+        mdit.options["mdformat"] (optional)"""
 
     def update_mdit(self, mdit: MarkdownIt) -> None:
         """Update the parser, e.g. by adding a plugin: `mdit.use(myplugin)`"""
-        pass
 
     def render_token(
         self,

--- a/mdformat/plugins.py
+++ b/mdformat/plugins.py
@@ -27,7 +27,7 @@ CODEFORMATTERS: Mapping[str, Callable[[str, str], str]] = _load_codeformatters()
 class ParserExtensionInterface(Protocol):
     """A interface for parser extension plugins."""
 
-    def update_mdit(self, mdit: MarkdownIt, env: Optional[dict] = None) -> None:
+    def update_mdit(self, mdit: MarkdownIt) -> None:
         """Update the parser, e.g. by adding a plugin: `mdit.use(myplugin)`"""
         pass
 

--- a/mdformat/plugins.py
+++ b/mdformat/plugins.py
@@ -27,7 +27,7 @@ CODEFORMATTERS: Mapping[str, Callable[[str, str], str]] = _load_codeformatters()
 class ParserExtensionInterface(Protocol):
     """A interface for parser extension plugins."""
 
-    def update_mdit(self, mdit: MarkdownIt) -> None:
+    def update_mdit(self, mdit: MarkdownIt, env: Optional[dict] = None) -> None:
         """Update the parser, e.g. by adding a plugin: `mdit.use(myplugin)`"""
         pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,4 +101,7 @@ commands = mypy {posargs:.}
 deps = pre-commit
 commands = pre-commit try-repo . mdformat --verbose --show-diff-on-failure --files CHANGELOG.md CONTRIBUTING.md README.md
 
+[testenv:py{36,37,38}-cli]
+commands = mdformat {posargs}
+
 """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,9 @@
 from io import StringIO
 import sys
-from unittest.mock import call, patch
 
 import pytest
 
 from mdformat._cli import run
-from mdformat.renderer import MDRenderer
 
 UNFORMATTED_MARKDOWN = "\n\n# A header\n\n"
 FORMATTED_MARKDOWN = "# A header\n"
@@ -68,47 +66,6 @@ def test_check__multi_fail(capsys, tmp_path):
     captured = capsys.readouterr()
     assert str(file_path1) in captured.err
     assert str(file_path2) in captured.err
-
-
-def test_options(tmp_path):
-    """Test that -o arguments are correctly added to the options dict."""
-    file_path = tmp_path / "test_markdown.md"
-    file_path.touch()
-
-    with patch.object(MDRenderer, "render", return_value="") as mock_method:
-        assert (
-            run((str(file_path), "--check", "-o", "a=1", "-o", "b=c", "-o", "d=True"))
-            == 0
-        )
-
-    calls = mock_method.call_args_list
-    assert len(calls) == 1, calls
-    expected = {
-        "maxNesting": 20,
-        "html": True,
-        "linkify": False,
-        "typographer": False,
-        "quotes": "“”‘’",
-        "xhtmlOut": True,
-        "breaks": False,
-        "langPrefix": "language-",
-        "highlight": None,
-        "a": 1,
-        "b": "c",
-        "d": True,
-        "parser_extension": [],
-        "codeformatters": {},
-    }
-    assert calls[0] == call([], expected, {}), calls[0]
-
-
-def test_env_bad(tmp_path, capsys):
-    file_path = tmp_path / "test_markdown.md"
-    file_path.touch()
-    with pytest.raises(SystemExit):
-        run((str(file_path), "-o", "bad"))
-    captured = capsys.readouterr()
-    assert "-o option must be in the form key=value" in captured.err, captured.err
 
 
 def test_dash_stdin(capsys, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,11 @@
 from io import StringIO
 import sys
+from unittest.mock import ANY, call, patch
+
+import pytest
 
 from mdformat._cli import run
+from mdformat.renderer import MDRenderer
 
 UNFORMATTED_MARKDOWN = "\n\n# A header\n\n"
 FORMATTED_MARKDOWN = "# A header\n"
@@ -31,8 +35,11 @@ def test_format__folder(tmp_path):
     assert file_path_3.read_text() == UNFORMATTED_MARKDOWN
 
 
-def test_invalid_file():
-    assert run(("this is not a valid filepath?`=|><@{[]\\/,.%¤#'",)) == 1
+def test_invalid_file(capsys):
+    with pytest.raises(SystemExit):
+        run(("this is not a valid filepath?`=|><@{[]\\/,.%¤#'",))
+    captured = capsys.readouterr()
+    assert "does not exist" in captured.err
 
 
 def test_check(tmp_path):
@@ -61,6 +68,31 @@ def test_check__multi_fail(capsys, tmp_path):
     captured = capsys.readouterr()
     assert str(file_path1) in captured.err
     assert str(file_path2) in captured.err
+
+
+def test_env(tmp_path):
+    """Test that env arguments are correctly passed as an env dict."""
+    file_path = tmp_path / "test_markdown.md"
+    file_path.touch()
+
+    with patch.object(MDRenderer, "render", return_value="") as mock_method:
+        assert (
+            run((str(file_path), "--check", "-e", "a=1", "-e", "b=c", "-e", "d=True"))
+            == 0
+        )
+
+    calls = mock_method.call_args_list
+    assert len(calls) == 1, calls
+    assert calls[0] == call([], ANY, {"a": 1, "b": "c", "d": True}), calls[0]
+
+
+def test_env_bad(tmp_path, capsys):
+    file_path = tmp_path / "test_markdown.md"
+    file_path.touch()
+    with pytest.raises(SystemExit):
+        run((str(file_path), "-e", "bad"))
+    captured = capsys.readouterr()
+    assert "-e option" in captured.err, captured.err
 
 
 def test_dash_stdin(capsys, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 from io import StringIO
 import sys
-from unittest.mock import ANY, call, patch
+from unittest.mock import call, patch
 
 import pytest
 
@@ -70,29 +70,45 @@ def test_check__multi_fail(capsys, tmp_path):
     assert str(file_path2) in captured.err
 
 
-def test_env(tmp_path):
-    """Test that env arguments are correctly passed as an env dict."""
+def test_options(tmp_path):
+    """Test that -o arguments are correctly added to the options dict."""
     file_path = tmp_path / "test_markdown.md"
     file_path.touch()
 
     with patch.object(MDRenderer, "render", return_value="") as mock_method:
         assert (
-            run((str(file_path), "--check", "-e", "a=1", "-e", "b=c", "-e", "d=True"))
+            run((str(file_path), "--check", "-o", "a=1", "-o", "b=c", "-o", "d=True"))
             == 0
         )
 
     calls = mock_method.call_args_list
     assert len(calls) == 1, calls
-    assert calls[0] == call([], ANY, {"a": 1, "b": "c", "d": True}), calls[0]
+    expected = {
+        "maxNesting": 20,
+        "html": True,
+        "linkify": False,
+        "typographer": False,
+        "quotes": "“”‘’",
+        "xhtmlOut": True,
+        "breaks": False,
+        "langPrefix": "language-",
+        "highlight": None,
+        "a": 1,
+        "b": "c",
+        "d": True,
+        "parser_extension": [],
+        "codeformatters": {},
+    }
+    assert calls[0] == call([], expected, {}), calls[0]
 
 
 def test_env_bad(tmp_path, capsys):
     file_path = tmp_path / "test_markdown.md"
     file_path.touch()
     with pytest.raises(SystemExit):
-        run((str(file_path), "-e", "bad"))
+        run((str(file_path), "-o", "bad"))
     captured = capsys.readouterr()
-    assert "-e option" in captured.err, captured.err
+    assert "-o option must be in the form key=value" in captured.err, captured.err
 
 
 def test_dash_stdin(capsys, monkeypatch):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,5 +1,7 @@
+import argparse
 from textwrap import dedent
 from typing import List, Optional, Tuple
+from unittest.mock import call, patch
 
 from markdown_it import MarkdownIt
 from markdown_it.extensions import front_matter
@@ -7,6 +9,7 @@ from markdown_it.token import Token
 import yaml
 
 import mdformat
+from mdformat._cli import run
 from mdformat.plugins import PARSER_EXTENSIONS
 from mdformat.renderer import MARKERS, MDRenderer
 
@@ -104,3 +107,49 @@ def test_table(monkeypatch):
     other text
     """
     )
+
+
+class ExamplePluginWithCli:
+    """A class for extending the base parser."""
+
+    @staticmethod
+    def update_mdit(mdit: MarkdownIt):
+        """Update the parser, e.g. by adding a plugin: `mdit.use(myplugin)`"""
+        mdit.enable("table")
+
+    @staticmethod
+    def add_cli_options(parser: argparse.ArgumentParser) -> None:
+        """Add options to the mdformat CLI, to be stored in
+        mdit.options["mdformat"]"""
+        parser.add_argument("--o1", type=str)
+        parser.add_argument("--o2", type=str, default="a")
+        parser.add_argument("--o3", dest="arg_name", type=int)
+
+
+def test_cli_options(monkeypatch, tmp_path):
+    """Test that -o arguments are correctly added to the options dict."""
+    monkeypatch.setitem(PARSER_EXTENSIONS, "table", ExamplePluginWithCli)
+    file_path = tmp_path / "test_markdown.md"
+    file_path.touch()
+
+    with patch.object(MDRenderer, "render", return_value="") as mock_method:
+        assert run((str(file_path), "--o1", "other", "--o3", "4")) == 0
+
+    calls = mock_method.call_args_list
+    assert len(calls) == 1, calls
+    expected = {
+        "maxNesting": 20,
+        "html": True,
+        "linkify": False,
+        "typographer": False,
+        "quotes": "“”‘’",
+        "xhtmlOut": True,
+        "breaks": False,
+        "langPrefix": "language-",
+        "highlight": None,
+        "store_labels": True,
+        "parser_extension": [ExamplePluginWithCli],
+        "codeformatters": {},
+        "mdformat": {"arg_name": 4, "check": False, "o1": "other", "o2": "a"},
+    }
+    assert calls[0] == call([], expected, {}), calls[0]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -15,7 +15,7 @@ class ExampleFrontMatterPlugin:
     """A class for extending the base parser."""
 
     @staticmethod
-    def update_mdit(mdit: MarkdownIt, env: Optional[dict] = None):
+    def update_mdit(mdit: MarkdownIt):
         """Update the parser, e.g. by adding a plugin: `mdit.use(myplugin)`"""
         mdit.use(front_matter.front_matter_plugin)
 
@@ -61,7 +61,7 @@ class ExampleTablePlugin:
     """A class for extending the base parser."""
 
     @staticmethod
-    def update_mdit(mdit: MarkdownIt, env: Optional[dict] = None):
+    def update_mdit(mdit: MarkdownIt):
         """Update the parser, e.g. by adding a plugin: `mdit.use(myplugin)`"""
         mdit.enable("table")
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -150,6 +150,12 @@ def test_cli_options(monkeypatch, tmp_path):
         "store_labels": True,
         "parser_extension": [ExamplePluginWithCli],
         "codeformatters": {},
-        "mdformat": {"arg_name": 4, "check": False, "o1": "other", "o2": "a"},
+        "mdformat": {
+            "arg_name": 4,
+            "check": False,
+            "o1": "other",
+            "o2": "a",
+            "paths": [str(file_path)],
+        },
     }
     assert calls[0] == call([], expected, {}), calls[0]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -15,7 +15,7 @@ class ExampleFrontMatterPlugin:
     """A class for extending the base parser."""
 
     @staticmethod
-    def update_mdit(mdit: MarkdownIt):
+    def update_mdit(mdit: MarkdownIt, env: Optional[dict] = None):
         """Update the parser, e.g. by adding a plugin: `mdit.use(myplugin)`"""
         mdit.use(front_matter.front_matter_plugin)
 
@@ -61,7 +61,7 @@ class ExampleTablePlugin:
     """A class for extending the base parser."""
 
     @staticmethod
-    def update_mdit(mdit: MarkdownIt):
+    def update_mdit(mdit: MarkdownIt, env: Optional[dict] = None):
         """Update the parser, e.g. by adding a plugin: `mdit.use(myplugin)`"""
         mdit.enable("table")
 


### PR DESCRIPTION
This provides a hook for passing variables to the parsing/render process,
which in-turn provides a simple way of allowing plugins to accept variable arguments from the API or CLI.

~~Note this is back-incompatible for parser plugins, since `update_mdit` now also gets passed this env dict.~~