### PR TITLE
✨ NEW: Keep link references

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,4 +81,4 @@ jobs:
         pip install pre-commit
 
     - name: run hook against repository
-      run: pre-commit try-repo . mdformat --verbose --all-files --show-diff-on-failure
+      run: pre-commit try-repo . mdformat --verbose --show-diff-on-failure --files CHANGELOG.md CONTRIBUTING.md README.md

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The features/opinions of the formatter include:
 - Strip trailing and leading whitespace
 - Always use ATX style headings
 - Consistent indentation for contents of block quotes and list items
-- Reformat reference links as inline links
+- Move all link references to the bottom of the document (sorted by label)
 - Reformat indented code blocks as fenced code blocks
 - Separate blocks with a single empty line
   (an exception being tight lists where the separator is a single newline character)

--- a/mdformat/_api.py
+++ b/mdformat/_api.py
@@ -12,6 +12,10 @@ def text(
 ) -> str:
     """Format a Markdown string."""
     markdown_it = MarkdownIt(renderer_cls=MDRenderer)
+    # store reference labels in link/image tokens
+    markdown_it.options["store_labels"] = True
+    markdown_it.options["mdformat"] = {"keep_references": True}
+
     markdown_it.options["parser_extension"] = []
     for name in extensions:
         plugin = mdformat.plugins.PARSER_EXTENSIONS[name]

--- a/mdformat/_api.py
+++ b/mdformat/_api.py
@@ -14,7 +14,6 @@ def text(
     markdown_it = MarkdownIt(renderer_cls=MDRenderer)
     # store reference labels in link/image tokens
     markdown_it.options["store_labels"] = True
-    markdown_it.options["mdformat"] = {"keep_references": True}
 
     markdown_it.options["parser_extension"] = []
     for name in extensions:

--- a/mdformat/renderer/__init__.py
+++ b/mdformat/renderer/__init__.py
@@ -111,14 +111,14 @@ class MDRenderer:
 
             if env.get("used_refs", None):
                 rendered_content += "\n\n"
-                rendered_content += self.write_references(env)
+                rendered_content += self._write_references(env)
 
             rendered_content += "\n"
 
         return rendered_content
 
     @staticmethod
-    def write_references(env: dict) -> str:
+    def _write_references(env: dict) -> str:
         text = ""
         for key in sorted(env.get("used_refs", [])):
             ref = env["references"][key]

--- a/mdformat/renderer/__init__.py
+++ b/mdformat/renderer/__init__.py
@@ -109,9 +109,7 @@ class MDRenderer:
             rendered_content = removesuffix(rendered_content, MARKERS.BLOCK_SEPARATOR)
             rendered_content = rendered_content.replace(MARKERS.BLOCK_SEPARATOR, "\n\n")
 
-            if options.get("mdformat", {}).get("keep_references", False) and env.get(
-                "references", None
-            ):
+            if env.get("used_refs", None):
                 rendered_content += "\n\n"
                 rendered_content += self.write_references(env)
 
@@ -122,7 +120,7 @@ class MDRenderer:
     @staticmethod
     def write_references(env: dict) -> str:
         text = ""
-        for key in sorted(env.get("references", {}).keys()):
+        for key in sorted(env.get("used_refs", [])):
             ref = env["references"][key]
             item = f"[{key.lower()}]: {ref['href']}"
             if ref["title"]:

--- a/mdformat/renderer/__init__.py
+++ b/mdformat/renderer/__init__.py
@@ -126,6 +126,6 @@ class MDRenderer:
             ref = env["references"][key]
             item = f"[{key.lower()}]: {ref['href']}"
             if ref["title"]:
-                item += f'"{ref["title"]}"'
+                item += f' "{ref["title"]}"'
             text += item + "\n"
         return text.rstrip()

--- a/mdformat/renderer/__init__.py
+++ b/mdformat/renderer/__init__.py
@@ -27,6 +27,7 @@ class MDRenderer:
         options: dict,
         env: dict,
         *,
+        finalize: bool = True,
         _recursion_level: int = 0,
     ) -> str:
         """Takes token stream and generates Markdown.
@@ -35,6 +36,7 @@ class MDRenderer:
             tokens: A list of block tokens to render
             options: Params of parser instance
             env: Additional data from parsed input
+            finalize: replace markers and write references
         """
         assert _recursion_level in {
             0,
@@ -66,7 +68,11 @@ class MDRenderer:
             if token.type == "inline":
                 # inline tokens require nested rendering
                 result = self.render(
-                    token.children, options, env, _recursion_level=_recursion_level + 1
+                    token.children,
+                    options,
+                    env,
+                    finalize=finalize,
+                    _recursion_level=_recursion_level + 1,
                 )
             else:
                 # otherwise use a built-in renderer
@@ -99,8 +105,27 @@ class MDRenderer:
         rendered_content = text_stack.pop()
         assert not text_stack, "Text stack should be empty before returning"
 
-        if not _recursion_level:
+        if finalize and not _recursion_level:
             rendered_content = removesuffix(rendered_content, MARKERS.BLOCK_SEPARATOR)
             rendered_content = rendered_content.replace(MARKERS.BLOCK_SEPARATOR, "\n\n")
+
+            if options.get("mdformat", {}).get("keep_references", False) and env.get(
+                "references", None
+            ):
+                rendered_content += "\n\n"
+                rendered_content += self.write_references(env)
+
             rendered_content += "\n"
+
         return rendered_content
+
+    @staticmethod
+    def write_references(env: dict) -> str:
+        text = ""
+        for key in sorted(env.get("references", {}).keys()):
+            ref = env["references"][key]
+            item = f"[{key.lower()}]: {ref['href']}"
+            if ref["title"]:
+                item += f'"{ref["title"]}"'
+            text += item + "\n"
+        return text.rstrip()

--- a/mdformat/renderer/_token_renderers.py
+++ b/mdformat/renderer/_token_renderers.py
@@ -60,6 +60,11 @@ def image(tokens: List[Token], idx: int, options: dict, env: dict) -> str:
     label = token.attrGet("alt")
     assert label is not None
 
+    if token.meta.get("label", None) and options.get("mdformat", {}).get(
+        "keep_references", False
+    ):
+        return f"![{label}][{token.meta['label'].lower()}]"
+
     uri = token.attrGet("src")
     assert uri is not None
     title = token.attrGet("title")

--- a/mdformat/renderer/_token_renderers.py
+++ b/mdformat/renderer/_token_renderers.py
@@ -30,9 +30,8 @@ def link_close(tokens: List[Token], idx: int, options: dict, env: dict) -> str:
     if token.markup == "autolink":
         return ">"
     open_tkn = find_opening_token(tokens, idx)
-    if open_tkn.meta.get("label", None) and options.get("mdformat", {}).get(
-        "keep_references", False
-    ):
+    if open_tkn.meta.get("label", None):
+        env.setdefault("used_refs", set()).add(open_tkn.meta["label"])
         return f"][{open_tkn.meta['label'].lower()}]"
     attrs = dict(open_tkn.attrs)
     uri = attrs["href"]
@@ -60,9 +59,8 @@ def image(tokens: List[Token], idx: int, options: dict, env: dict) -> str:
     label = token.attrGet("alt")
     assert label is not None
 
-    if token.meta.get("label", None) and options.get("mdformat", {}).get(
-        "keep_references", False
-    ):
+    if token.meta.get("label", None):
+        env.setdefault("used_refs", set()).add(token.meta["label"])
         if label == token.meta["label"].lower():
             return f"![{label}]"
         return f"![{label}][{token.meta['label'].lower()}]"

--- a/mdformat/renderer/_token_renderers.py
+++ b/mdformat/renderer/_token_renderers.py
@@ -30,6 +30,10 @@ def link_close(tokens: List[Token], idx: int, options: dict, env: dict) -> str:
     if token.markup == "autolink":
         return ">"
     open_tkn = find_opening_token(tokens, idx)
+    if open_tkn.meta.get("label", None) and options.get("mdformat", {}).get(
+        "keep_references", False
+    ):
+        return f"][{open_tkn.meta['label'].lower()}]"
     attrs = dict(open_tkn.attrs)
     uri = attrs["href"]
     title = attrs.get("title")

--- a/mdformat/renderer/_token_renderers.py
+++ b/mdformat/renderer/_token_renderers.py
@@ -63,6 +63,8 @@ def image(tokens: List[Token], idx: int, options: dict, env: dict) -> str:
     if token.meta.get("label", None) and options.get("mdformat", {}).get(
         "keep_references", False
     ):
+        if label == token.meta["label"].lower():
+            return f"![{label}]"
         return f"![{label}][{token.meta['label'].lower()}]"
 
     uri = token.attrGet("src")

--- a/poetry.lock
+++ b/poetry.lock
@@ -115,7 +115,7 @@ description = "Python port of markdown-it. Markdown parsing, done right!"
 name = "markdown-it-py"
 optional = false
 python-versions = "~=3.6"
-version = "0.5.4"
+version = "0.5.5"
 
 [package.dependencies]
 attrs = ">=19,<21"
@@ -125,14 +125,6 @@ code_style = ["pre-commit (2.6)"]
 compare = ["commonmark (>=0.9.1,<0.10.0)", "markdown (>=3.2,<4.0)", "mistune (>=0.8.4,<0.9.0)", "mistletoe-ebp (>=0.10.0,<0.11.0)", "panflute (>=1.12,<2.0)"]
 rtd = ["myst-nb (>=0.10.0,<0.11.0)", "sphinx-book-theme", "sphinx-panels (>=0.4.0,<0.5.0)", "sphinx-copybutton", "sphinx (>=2,<4)", "pyyaml"]
 testing = ["coverage", "pytest (>=3.6,<4)", "pytest-cov", "pytest-regressions", "pytest-benchmark (>=3.2,<4.0)", "psutil"]
-
-[[package]]
-category = "dev"
-description = "More routines for operating on iterables, beyond itertools"
-name = "more-itertools"
-optional = false
-python-versions = ">=3.5"
-version = "8.5.0"
 
 [[package]]
 category = "dev"
@@ -240,14 +232,13 @@ description = "pytest: simple powerful testing with Python"
 name = "pytest"
 optional = false
 python-versions = ">=3.5"
-version = "6.0.2"
+version = "6.1.0"
 
 [package.dependencies]
 atomicwrites = ">=1.0"
 attrs = ">=17.4.0"
 colorama = "*"
 iniconfig = "*"
-more-itertools = ">=4.0.0"
 packaging = "*"
 pluggy = ">=0.12,<1.0"
 py = ">=1.8.2"
@@ -357,7 +348,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "899c846bd8557db6c96ccec52e064b8cb0eb16120bda1bde5c27019591f3ea3e"
+content-hash = "2ff21d15008d7ffdc084e9473f92d1ff393936ddbf614911e47a97ea75a0da58"
 lock-version = "1.0"
 python-versions = "^3.6"
 
@@ -435,12 +426,8 @@ iniconfig = [
     {file = "iniconfig-1.0.1.tar.gz", hash = "sha256:e5f92f89355a67de0595932a6c6c02ab4afddc6fcdc0bfc5becd0d60884d3f69"},
 ]
 markdown-it-py = [
-    {file = "markdown-it-py-0.5.4.tar.gz", hash = "sha256:f18ec8f1c1a424ab2a9ac06b5ba87d6d2a01e450cd8678edbc71002106dd68a8"},
-    {file = "markdown_it_py-0.5.4-py3-none-any.whl", hash = "sha256:d1782446f7fcbf2db9a1bc0430230cb879498ad6d76168d7e7c762bab04cb4ea"},
-]
-more-itertools = [
-    {file = "more-itertools-8.5.0.tar.gz", hash = "sha256:6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20"},
-    {file = "more_itertools-8.5.0-py3-none-any.whl", hash = "sha256:9b30f12df9393f0d28af9210ff8efe48d10c94f73e5daf886f10c4b0b0b4f03c"},
+    {file = "markdown-it-py-0.5.5.tar.gz", hash = "sha256:0513fcc7300b6b1da7713c11b018336eeda12eddf49cbfde0865a5febfa27758"},
+    {file = "markdown_it_py-0.5.5-py3-none-any.whl", hash = "sha256:62de2951c83764b234304bc48fd68d21bb0495051845061c2cb66952afe069c3"},
 ]
 mypy = [
     {file = "mypy-0.782-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:2c6cde8aa3426c1682d35190b59b71f661237d74b053822ea3d748e2c9578a7c"},
@@ -487,8 +474,8 @@ pyparsing = [
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
-    {file = "pytest-6.0.2-py3-none-any.whl", hash = "sha256:0e37f61339c4578776e090c3b8f6b16ce4db333889d65d0efb305243ec544b40"},
-    {file = "pytest-6.0.2.tar.gz", hash = "sha256:c8f57c2a30983f469bf03e68cdfa74dc474ce56b8f280ddcb080dfd91df01043"},
+    {file = "pytest-6.1.0-py3-none-any.whl", hash = "sha256:1cd09785c0a50f9af72220dd12aa78cfa49cbffc356c61eab009ca189e018a33"},
+    {file = "pytest-6.1.0.tar.gz", hash = "sha256:d010e24666435b39a4cf48740b039885642b6c273a3f77be3e7e03554d2806b7"},
 ]
 pytest-cov = [
     {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ mdformat = "mdformat.__main__:run"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-markdown-it-py = ">=0.4.7, <0.6.0"
+markdown-it-py = ">=0.5.5, <0.6.0"
 importlib-metadata = { version = ">=0.12", python = "<3.8" }
 typing-extensions= { version = "*", python = "<3.8" }
 
@@ -99,6 +99,6 @@ commands = mypy {posargs:.}
 
 [testenv:py{36,37,38}-hook]
 deps = pre-commit
-commands = pre-commit try-repo . mdformat --verbose --all-files --show-diff-on-failure
+commands = pre-commit try-repo . mdformat --verbose --show-diff-on-failure --files CHANGELOG.md CONTRIBUTING.md README.md
 
 """

--- a/tests/data/fixtures.md
+++ b/tests/data/fixtures.md
@@ -91,7 +91,7 @@ references:
 .
 [text](<link1>) [text](<link2> "title") [ref1][ref1] [text][ref1]
 
-![text](link1) ![text](link2 "title") ![ref1][ref1] ![text][ref1]
+![text](link1) ![text](link2 "title") ![ref1] ![text][ref1]
 
 [ref1]: link4
 [ref2]: link3 "title"

--- a/tests/data/fixtures.md
+++ b/tests/data/fixtures.md
@@ -85,9 +85,13 @@ references:
 
 [text](link1) [text](link2 "title") [ref1] [text][ref1]
 
+![text](link1) ![text](link2 "title") ![ref1] ![text][ref1]
+
 [ref1]: link4
 .
 [text](<link1>) [text](<link2> "title") [ref1][ref1] [text][ref1]
+
+![text](link1) ![text](link2 "title") ![ref1][ref1] ![text][ref1]
 
 [ref1]: link4
 [ref2]: link3 "title"

--- a/tests/data/fixtures.md
+++ b/tests/data/fixtures.md
@@ -81,14 +81,14 @@ numbered lists
 
 references:
 .
-[ref2]: link3
+[ref2]: link3 "title"
 
-[text](link1) [ref1] [text][ref1]
+[text](link1) [text](link2 "title") [ref1] [text][ref1]
 
-[ref1]: link2
+[ref1]: link4
 .
-[text](<link1>) [ref1][ref1] [text][ref1]
+[text](<link1>) [text](<link2> "title") [ref1][ref1] [text][ref1]
 
-[ref1]: link2
-[ref2]: link3
+[ref1]: link4
+[ref2]: link3 "title"
 .

--- a/tests/data/fixtures.md
+++ b/tests/data/fixtures.md
@@ -83,15 +83,16 @@ references:
 .
 [ref2]: link3 "title"
 
-[text](link1) [text](link2 "title") [ref1] [text][ref1]
+[text](link1) [text](link2 "title") [ref1] [ref2] [text][ref1]
 
-![text](link1) ![text](link2 "title") ![ref1] ![text][ref1]
+![text](link1) ![text](link2 "title") ![ref1] ![ref2] ![text][ref1]
 
 [ref1]: link4
+[unused]: link5
 .
-[text](<link1>) [text](<link2> "title") [ref1][ref1] [text][ref1]
+[text](<link1>) [text](<link2> "title") [ref1][ref1] [ref2][ref2] [text][ref1]
 
-![text](link1) ![text](link2 "title") ![ref1] ![text][ref1]
+![text](link1) ![text](link2 "title") ![ref1] ![ref2] ![text][ref1]
 
 [ref1]: link4
 [ref2]: link3 "title"

--- a/tests/data/fixtures.md
+++ b/tests/data/fixtures.md
@@ -1,0 +1,94 @@
+strip paragraph lines
+.
+trailing whitespace 
+at the end of paragraph lines 
+should be stripped                   
+.
+trailing whitespace
+at the end of paragraph lines
+should be stripped
+.
+
+strip quotes
+.
+> Paragraph 1
+> 
+> Paragraph 2
+.
+> Paragraph 1
+>
+> Paragraph 2
+.
+
+no escape ampersand
+.
+R&B, rock & roll
+.
+R&B, rock & roll
+.
+
+list whitespaces
+.
+- item one
+  
+- item two
+  - sublist
+  
+  - sublist
+.
+- item one
+
+- item two
+
+  - sublist
+
+  - sublist
+.
+
+convert setext to ATX heading
+.
+Top level heading
+=========
+
+2nd level heading
+---------
+.
+# Top level heading
+
+## 2nd level heading
+.
+
+Lists with different bullets
+.
+- a
+- b
+* c
+.
+- a
+- b
+
+* c
+.
+
+numbered lists
+.
+1. a
+2. b
+.
+1. a
+1. b
+.
+
+references:
+.
+[ref2]: link3
+
+[text](link1) [ref1] [text][ref1]
+
+[ref1]: link2
+.
+[text](<link1>) [ref1][ref1] [text][ref1]
+
+[ref1]: link2
+[ref2]: link3
+.

--- a/tests/test_renderer_style.py
+++ b/tests/test_renderer_style.py
@@ -19,4 +19,4 @@ def test_renderer_style(line, title, text, expected):
     md_new = mdit.render(text)
     if not md_new == expected:
         print(md_new)
-        assert md_new == expected
+    assert md_new == expected

--- a/tests/test_renderer_style.py
+++ b/tests/test_renderer_style.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 
+from markdown_it import MarkdownIt
 from markdown_it.utils import read_fixture_file
 import pytest
 
-from mdformat import text as render
+from mdformat.renderer import MDRenderer
 
 STYLE_CASES = read_fixture_file(Path(__file__).parent / "data" / "fixtures.md")
 
@@ -13,6 +14,9 @@ STYLE_CASES = read_fixture_file(Path(__file__).parent / "data" / "fixtures.md")
 )
 def test_renderer_style(line, title, text, expected):
     """Test Markdown renderer renders expected style."""
-    md_new = render(text)
-    print(md_new)
-    assert md_new == expected
+    mdit = MarkdownIt(renderer_cls=MDRenderer)
+    mdit.options["store_labels"] = True
+    md_new = mdit.render(text)
+    if not md_new == expected:
+        print(md_new)
+        assert md_new == expected

--- a/tests/test_renderer_style.py
+++ b/tests/test_renderer_style.py
@@ -1,45 +1,18 @@
-from markdown_it import MarkdownIt
+from pathlib import Path
+
+from markdown_it.utils import read_fixture_file
 import pytest
 
-from mdformat.renderer import MDRenderer
+from mdformat import text as render
 
-STYLE_CASES = (
-    {
-        "name": "strip paragraph lines",
-        "input_md": "trailing whitespace \n"
-        "at the end of paragraph lines \n"
-        "should be stripped                   \n",
-        "output_md": "trailing whitespace\n"
-        "at the end of paragraph lines\n"
-        "should be stripped\n",
-    },
-    {
-        "name": "strip quotes",
-        "input_md": "> Paragraph 1\n" "> \n" "> Paragraph 2\n",
-        "output_md": "> Paragraph 1\n" ">\n" "> Paragraph 2\n",
-    },
-    {
-        "name": "no escape ampersand",
-        "input_md": "R&B, rock & roll\n",
-        "output_md": "R&B, rock & roll\n",
-    },
-    {
-        "name": "list whitespaces",
-        "input_md": "- item one\n  \n- item two\n  - sublist\n    \n  - sublist\n",
-        "output_md": "- item one\n\n- item two\n\n  - sublist\n\n  - sublist\n",
-    },
-    {
-        "name": "convert setext to ATX heading",
-        "input_md": "Top level heading\n=========\n\n2nd level heading\n---------",
-        "output_md": "# Top level heading\n\n## 2nd level heading\n",
-    },
+STYLE_CASES = read_fixture_file(Path(__file__).parent / "data" / "fixtures.md")
+
+
+@pytest.mark.parametrize(
+    "line,title,text,expected", STYLE_CASES, ids=[f[1] for f in STYLE_CASES]
 )
-
-
-@pytest.mark.parametrize("entry", STYLE_CASES, ids=[c["name"] for c in STYLE_CASES])
-def test_renderer_style(entry):
+def test_renderer_style(line, title, text, expected):
     """Test Markdown renderer renders expected style."""
-    md_original = entry["input_md"]
-    md_new = MarkdownIt(renderer_cls=MDRenderer).render(md_original)
-    expected_md = entry["output_md"]
-    assert md_new == expected_md
+    md_new = render(text)
+    print(md_new)
+    assert md_new == expected


### PR DESCRIPTION
Utilise the new `store_labels` option I introduced in mardown-it-py, to keep link/image reference labels, instead of their resolved href. Then output the (sorted) references at the end of the document.

Notes:
- I've left a "hook" to turn this feature on/off: `markdown_it.options["mdformat"] = {"keep_references": True}`, this could be turned into a CLI option, if desired.
- References are always normalized using `str.upper()` in markdown-it, but, as a style choice, I convert them to `str.lower()`
- I've added a `finalize` key-word argument to `MDRenderer.render`. This is for use by plugins (like mdformat-tables) that need to run "nested rendering", during which they do not want these references output.