### PR TITLE
Make equality safeguard ensure HTML whitespace isnt removed

### DIFF
--- a/mdformat/_util.py
+++ b/mdformat/_util.py
@@ -31,11 +31,11 @@ def is_md_equal(
         for codeclass in codeformatters:
             html = re.sub(
                 f'<code class="language-{codeclass}">.*</code>',
-                " ",
+                "",
                 html,
                 flags=re.DOTALL,
             )
-        html = re.sub(r"\s+", "", html)
+        html = re.sub(r"\s+", " ", html)
         html_texts[key] = html
 
     return html_texts["md1"] == html_texts["md2"]

--- a/mdformat/_util.py
+++ b/mdformat/_util.py
@@ -16,9 +16,10 @@ def is_md_equal(
 ) -> bool:
     """Check if two Markdown produce the same HTML.
 
-    Renders HTML from both Markdown strings, strips whitespace and
-    checks equality. Note that this is not a perfect solution, as there
-    can be meaningful whitespace in HTML, e.g. in a <code> block.
+    Renders HTML from both Markdown strings, reduces consecutive
+    whitespace to a single space and checks equality. Note that this is
+    not a perfect solution, as there can be meaningful whitespace in
+    HTML, e.g. in a <code> block.
     """
     html_texts = {}
     mdit = MarkdownIt()
@@ -30,7 +31,7 @@ def is_md_equal(
         for codeclass in codeformatters:
             html = re.sub(
                 f'<code class="language-{codeclass}">.*</code>',
-                "",
+                " ",
                 html,
                 flags=re.DOTALL,
             )


### PR DESCRIPTION
@chrisjsewell We discussed this change before here https://github.com/executablebooks/mdformat/pull/46

I'd like to make this change as I'm implementing paragraph wrap modes that modify whitespace more than the default mode, and would feel more confident with this change.

I think the point you made in https://github.com/executablebooks/mdformat/pull/46 about `|a|` vs `| a |` when formatting tables shouldn't be an issue as that is Markdown formatting, but the equivalence check deals with rendered HTML, where this whitespace difference shouldn't be present. Am I thinking this right? Can you see any other issues merging this?