### PR TITLE
renderer: Add a "translator" option

### DIFF
--- a/mdformat/renderer/_container_renderers.py
+++ b/mdformat/renderer/_container_renderers.py
@@ -144,6 +144,11 @@ def ordered_list_close(
 def paragraph_close(  # noqa: C901
     text: str, tokens: Sequence[Token], idx: int, options: Mapping[str, Any], env: dict
 ) -> str:
+    if "mdformat" in options and "translator" in options["mdformat"]:
+        text = options["mdformat"]["translator"].gettext(
+            text.replace("\n", " ").strip()
+        )
+
     lines = text.split("\n")
 
     for i in range(len(lines)):
@@ -209,6 +214,9 @@ def heading_close(
     # There can be newlines in setext headers, but we make an ATX
     # header always. Convert newlines to spaces.
     text = text.replace("\n", " ").rstrip()
+
+    if "mdformat" in options and "translator" in options["mdformat"]:
+        text = options["mdformat"]["translator"].gettext(text.lstrip())
 
     # If the text ends in a sequence of hashes (#), the hashes will be
     # interpreted as an optional closing sequence of the heading, and


### PR DESCRIPTION
Newlines in paragraph text are replaced with spaces, and text is stripped of left and right whitespace, to have the same behavior as in Sphinx: https://github.com/sphinx-doc/sphinx/blob/v3.4.0/sphinx/util/nodes.py#L276

The `translator` option would usually be the return value of `gettext.translation`: https://docs.python.org/3/library/gettext.html#gettext.translation
