### PR TITLE
Fix a CLI crash when terminal window width is less than 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 This log documents all Python API or CLI breaking backwards incompatible changes.
 Note that there is currently no guarantee for a stable Markdown formatting style across versions.
 
+## 0.5.7
+
+- Fixed
+  - CLI crash when formatting standard error output and the operating system reports a terminal window width of zero or less
+    ([#131](https://github.com/executablebooks/mdformat/issues/131)).
+    Thank you [ehontoria](https://github.com/ehontoria) for the issue.
+
 ## 0.5.6
 
 - Changed

--- a/mdformat/_cli.py
+++ b/mdformat/_cli.py
@@ -173,8 +173,12 @@ def wrap_paragraphs(paragraphs: Iterable[str]) -> str:
     End the string in a newline.
     """
     terminal_width, _ = shutil.get_terminal_size()
+    if 0 < terminal_width < 80:
+        wrap_width = terminal_width
+    else:
+        wrap_width = 80
     wrapper = textwrap.TextWrapper(
-        break_long_words=False, break_on_hyphens=False, width=min(terminal_width, 80)
+        break_long_words=False, break_on_hyphens=False, width=wrap_width
     )
     return "\n\n".join(wrapper.fill(p) for p in paragraphs) + "\n"
 


### PR DESCRIPTION
Fixes https://github.com/executablebooks/mdformat/issues/131