### PR TITLE
Adding reference to mdformat-frontmatter as an available plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,4 +260,9 @@ if you wish to implement a new parser extension plugin.
     <td><code>toc</code></td>
     <td>Adds the capability to auto-generate a table of contents</td>
   </tr>
+  <tr>
+    <td><a href="https://github.com/butler54/mdformat-toc">mdformat-frontmatter</a></td>
+    <td><code>frontmatter</code></td>
+    <td>Adds the capability parse yaml headers to markdown documents.</td>
+  </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -263,6 +263,6 @@ if you wish to implement a new parser extension plugin.
   <tr>
     <td><a href="https://github.com/butler54/mdformat-frontmatter">mdformat-frontmatter</a></td>
     <td><code>frontmatter</code></td>
-    <td>Adds the capability parse yaml headers to markdown documents.</td>
+    <td>Adds support for front matter, and formats YAML front matter</td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ if you wish to implement a new parser extension plugin.
     <td>Adds the capability to auto-generate a table of contents</td>
   </tr>
   <tr>
-    <td><a href="https://github.com/butler54/mdformat-toc">mdformat-frontmatter</a></td>
+    <td><a href="https://github.com/butler54/mdformat-frontmatter">mdformat-frontmatter</a></td>
     <td><code>frontmatter</code></td>
     <td>Adds the capability parse yaml headers to markdown documents.</td>
   </tr>


### PR DESCRIPTION
I recently created a plugin to allow mdformat to handle yaml headers used by some tools. This PR is to add that plugin to the documentation of mdformat.

Signed-off-by: Chris Butler <chris@thebutlers.me>