### PR TITLE
BREAKING: Add collaborative render postprocessors for plugins. Input new `RenderContext` to both renderers and postprocessors

### DIFF
--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -90,17 +90,17 @@ Mdformat parser extension plugins need to adhere to the `mdformat.plugins.Parser
 ```python
 from typing import Mapping
 from markdown_it import MarkdownIt
-from mdformat.renderer.typing import RendererFunc
+from mdformat.renderer.typing import Renderer
 
 
 def update_mdit(mdit: MarkdownIt) -> None:
-   """Update the parser, e.g. by adding a plugin: `mdit.use(myplugin)`"""
+    """Update the parser, e.g. by adding a plugin: `mdit.use(myplugin)`"""
 
 
-# A mapping from `RenderTreeNode.type` value to a `RendererFunc` that can
+# A mapping from `RenderTreeNode.type` value to a `Renderer` that can
 # render the given `RenderTreeNode` type. These functions override the default
-# `RendererFunc`s defined in `mdformat.renderer.DEFAULT_RENDERER_FUNCS`.
-RENDERER_FUNCS: Mapping[str, RendererFunc]
+# `Renderer`s defined in `mdformat.renderer.DEFAULT_RENDERERS`.
+RENDERERS: Mapping[str, Renderer]
 ```
 
 This interface needs to be exposed via entry point distribution metadata.

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -90,17 +90,17 @@ Mdformat parser extension plugins need to adhere to the `mdformat.plugins.Parser
 ```python
 from typing import Mapping
 from markdown_it import MarkdownIt
-from mdformat.renderer.typing import Renderer
+from mdformat.renderer.typing import Render
 
 
 def update_mdit(mdit: MarkdownIt) -> None:
     """Update the parser, e.g. by adding a plugin: `mdit.use(myplugin)`"""
 
 
-# A mapping from `RenderTreeNode.type` value to a `Renderer` that can
+# A mapping from `RenderTreeNode.type` value to a `Render` function that can
 # render the given `RenderTreeNode` type. These functions override the default
-# `Renderer`s defined in `mdformat.renderer.DEFAULT_RENDERERS`.
-RENDERERS: Mapping[str, Renderer]
+# `Render` funcs defined in `mdformat.renderer.DEFAULT_RENDERERS`.
+RENDERERS: Mapping[str, Render]
 ```
 
 This interface needs to be exposed via entry point distribution metadata.

--- a/docs/users/changelog.md
+++ b/docs/users/changelog.md
@@ -3,6 +3,20 @@
 This log documents all Python API or CLI breaking backwards incompatible changes.
 Note that there is currently no guarantee for a stable Markdown formatting style across versions.
 
+## **unreleased**
+
+**NOTE:** Parser extension plugin API has changed in this release.
+
+- Added
+  - `POSTPROCESSORS` mapping to parser extension plugin API (i.e. `ParserExtensionInterface`),
+    providing a way for plugins to render syntax collaboratively.
+  - `Postprocess` type alias to `mdformat.renderer.typing`
+  - `mdformat.renderer.RenderContext`: a context object passed as input to `Render` and `Postprocess` functions
+- Changed
+  - Renamed `ParserExtensionInterface.RENDERER_FUNCS` as `ParserExtensionInterface.RENDERERS`
+  - Renamed `mdformat.renderer.typing.RendererFunc` as `mdformat.renderer.typing.Render`
+  - `mdformat.renderer.typing.Render` signature changed. Now takes `RenderContext` as input.
+
 ## 0.6.4
 
 - Fixed

--- a/docs/users/changelog.md
+++ b/docs/users/changelog.md
@@ -3,7 +3,7 @@
 This log documents all Python API or CLI breaking backwards incompatible changes.
 Note that there is currently no guarantee for a stable Markdown formatting style across versions.
 
-## **unreleased**
+## 0.7.0
 
 **NOTE:** Parser extension plugin API has changed in this release.
 

--- a/docs/users/changelog.md
+++ b/docs/users/changelog.md
@@ -16,6 +16,7 @@ Note that there is currently no guarantee for a stable Markdown formatting style
   - Renamed `ParserExtensionInterface.RENDERER_FUNCS` as `ParserExtensionInterface.RENDERERS`
   - Renamed `mdformat.renderer.typing.RendererFunc` as `mdformat.renderer.typing.Render`
   - `mdformat.renderer.typing.Render` signature changed. Now takes `RenderContext` as input.
+  - Renamed `mdformat.renderer.DEFAULT_RENDERER_FUNCS` as `mdformat.renderer.DEFAULT_RENDERERS`
 
 ## 0.6.4
 

--- a/mdformat/__main__.py
+++ b/mdformat/__main__.py
@@ -9,5 +9,5 @@ def run() -> NoReturn:
     sys.exit(exit_code)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     run()

--- a/mdformat/codepoints/_unicode_punctuation.py
+++ b/mdformat/codepoints/_unicode_punctuation.py
@@ -808,7 +808,7 @@ UNICODE_PUNCTUATION = frozenset(
     )
 )
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     import string
     import sys
     import unicodedata

--- a/mdformat/codepoints/_unicode_whitespace.py
+++ b/mdformat/codepoints/_unicode_whitespace.py
@@ -29,7 +29,7 @@ UNICODE_WHITESPACE = frozenset(
     )
 )
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     import string
     import sys
     import unicodedata

--- a/mdformat/plugins.py
+++ b/mdformat/plugins.py
@@ -4,7 +4,7 @@ from typing import Callable, Dict, Mapping
 from markdown_it import MarkdownIt
 
 from mdformat._compat import Protocol, importlib_metadata
-from mdformat.renderer.typing import RendererFunc
+from mdformat.renderer.typing import Postprocessor, Renderer
 
 
 def _load_codeformatters() -> Dict[str, Callable[[str, str], str]]:
@@ -24,10 +24,17 @@ class ParserExtensionInterface(Protocol):
     # (optional, default: False)
     CHANGES_AST: bool = False
 
-    # A mapping from `RenderTreeNode.type` to a `RendererFunc` that can
+    # A mapping from `RenderTreeNode.type` to a `Renderer` that can
     # render the given `RenderTreeNode` type. These override the default
-    # `RendererFunc`s defined in `mdformat.renderer.DEFAULT_RENDERER_FUNCS`.
-    RENDERER_FUNCS: Mapping[str, RendererFunc]
+    # `Renderer`s defined in `mdformat.renderer.DEFAULT_RENDERERS`.
+    RENDERERS: Mapping[str, Renderer]
+
+    # A mapping from `RenderTreeNode.type` to a `Postprocessor` that does
+    # postprocessing for the output of the `Renderer` function. `Postprocessor`s
+    # are collaborative: any number of plugins can define a postprocessor for a
+    # syntax type and all of them will run in series.
+    # (optional)
+    POSTPROCESSORS: Mapping[str, Postprocessor]
 
     @staticmethod
     def add_cli_options(parser: argparse.ArgumentParser) -> None:

--- a/mdformat/plugins.py
+++ b/mdformat/plugins.py
@@ -30,9 +30,10 @@ class ParserExtensionInterface(Protocol):
     RENDERERS: Mapping[str, Renderer]
 
     # A mapping from `RenderTreeNode.type` to a `Postprocessor` that does
-    # postprocessing for the output of the `Renderer` function. `Postprocessor`s
-    # are collaborative: any number of plugins can define a postprocessor for a
-    # syntax type and all of them will run in series.
+    # postprocessing for the output of the `Renderer` function. Unlike
+    # `Renderer`s, `Postprocessor`s are collaborative: any number of
+    # plugins can define a postprocessor for a syntax type and all of them
+    # will run in series.
     # (optional)
     POSTPROCESSORS: Mapping[str, Postprocessor]
 

--- a/mdformat/plugins.py
+++ b/mdformat/plugins.py
@@ -4,7 +4,7 @@ from typing import Callable, Dict, Mapping
 from markdown_it import MarkdownIt
 
 from mdformat._compat import Protocol, importlib_metadata
-from mdformat.renderer.typing import Postprocessor, Renderer
+from mdformat.renderer.typing import Postprocess, Render
 
 
 def _load_codeformatters() -> Dict[str, Callable[[str, str], str]]:
@@ -24,18 +24,18 @@ class ParserExtensionInterface(Protocol):
     # (optional, default: False)
     CHANGES_AST: bool = False
 
-    # A mapping from `RenderTreeNode.type` to a `Renderer` that can
+    # A mapping from `RenderTreeNode.type` to a `Render` function that can
     # render the given `RenderTreeNode` type. These override the default
-    # `Renderer`s defined in `mdformat.renderer.DEFAULT_RENDERERS`.
-    RENDERERS: Mapping[str, Renderer]
+    # `Render` funcs defined in `mdformat.renderer.DEFAULT_RENDERERS`.
+    RENDERERS: Mapping[str, Render]
 
-    # A mapping from `RenderTreeNode.type` to a `Postprocessor` that does
-    # postprocessing for the output of the `Renderer` function. Unlike
-    # `Renderer`s, `Postprocessor`s are collaborative: any number of
+    # A mapping from `RenderTreeNode.type` to a `Postprocess` that does
+    # postprocessing for the output of the `Render` function. Unlike
+    # `Render` funcs, `Postprocess` funcs are collaborative: any number of
     # plugins can define a postprocessor for a syntax type and all of them
     # will run in series.
     # (optional)
-    POSTPROCESSORS: Mapping[str, Postprocessor]
+    POSTPROCESSORS: Mapping[str, Postprocess]
 
     @staticmethod
     def add_cli_options(parser: argparse.ArgumentParser) -> None:

--- a/mdformat/renderer/__init__.py
+++ b/mdformat/renderer/__init__.py
@@ -15,7 +15,7 @@ from markdown_it.token import Token
 
 from mdformat.renderer._default_renderers import DEFAULT_RENDERERS
 from mdformat.renderer._tree import RenderContext, RenderTreeNode
-from mdformat.renderer.typing import Postprocessor
+from mdformat.renderer.typing import Postprocess
 
 LOGGER = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ class MDRenderer:
         # Update RENDERER_MAP defaults with renderer functions defined
         # by plugins.
         updated_renderers = {}
-        postprocessors: Dict[str, Tuple[Postprocessor, ...]] = {}
+        postprocessors: Dict[str, Tuple[Postprocess, ...]] = {}
         for plugin in options.get("parser_extension", []):
             for syntax_name, renderer_func in plugin.RENDERERS.items():
                 if syntax_name in updated_renderers:

--- a/mdformat/renderer/__init__.py
+++ b/mdformat/renderer/__init__.py
@@ -73,12 +73,11 @@ class MDRenderer:
                     )
                 else:
                     updated_renderers[syntax_name] = renderer_func
-            for syntax_name, pp in getattr(plugin, "POSTPROCESSORS", ()):
+            for syntax_name, pp in getattr(plugin, "POSTPROCESSORS", {}).items():
                 if syntax_name not in postprocessors:
                     postprocessors[syntax_name] = (pp,)
                 else:
                     postprocessors[syntax_name] += (pp,)
-
         renderer_map = MappingProxyType({**DEFAULT_RENDERERS, **updated_renderers})
         postprocessor_map = MappingProxyType(postprocessors)
         render_context = RenderContext(renderer_map, postprocessor_map, options, env)

--- a/mdformat/renderer/__init__.py
+++ b/mdformat/renderer/__init__.py
@@ -6,16 +6,16 @@ __all__ = (
     "RenderContext",
 )
 
-
 import logging
 from types import MappingProxyType
-from typing import Any, Mapping, MutableMapping, Sequence
+from typing import Any, Dict, Mapping, MutableMapping, Sequence, Tuple
 
 from markdown_it.common.normalize_url import unescape_string
 from markdown_it.token import Token
 
 from mdformat.renderer._default_renderers import DEFAULT_RENDERERS
 from mdformat.renderer._tree import RenderContext, RenderTreeNode
+from mdformat.renderer.typing import Postprocessor
 
 LOGGER = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ class MDRenderer:
         # Update RENDERER_MAP defaults with renderer functions defined
         # by plugins.
         updated_renderers = {}
-        postprocessors = {}
+        postprocessors: Dict[str, Tuple[Postprocessor, ...]] = {}
         for plugin in options.get("parser_extension", []):
             for syntax_name, renderer_func in plugin.RENDERERS.items():
                 if syntax_name in updated_renderers:

--- a/mdformat/renderer/_default_renderers.py
+++ b/mdformat/renderer/_default_renderers.py
@@ -21,7 +21,7 @@ from mdformat.renderer._util import (
     longest_consecutive_sequence,
     maybe_add_link_brackets,
 )
-from mdformat.renderer.typing import Renderer
+from mdformat.renderer.typing import Render
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
-def make_render_children(separator: str) -> Renderer:
+def make_render_children(separator: str) -> Render:
     def render_children(
         node: "RenderTreeNode",
         context: RenderContext,
@@ -190,7 +190,7 @@ def _render_inline_as_text(node: "RenderTreeNode", context: RenderContext) -> st
     def image_renderer(node: "RenderTreeNode", context: RenderContext) -> str:
         return _render_inline_as_text(node, context)
 
-    inline_renderers: Mapping[str, Renderer] = defaultdict(
+    inline_renderers: Mapping[str, Render] = defaultdict(
         lambda: make_render_children(""),
         {
             "text": text_renderer,
@@ -521,7 +521,7 @@ def ordered_list(node: "RenderTreeNode", context: RenderContext) -> str:
     return text
 
 
-DEFAULT_RENDERERS: Mapping[str, Renderer] = MappingProxyType(
+DEFAULT_RENDERERS: Mapping[str, Render] = MappingProxyType(
     {
         "inline": make_render_children(""),
         "root": make_render_children("\n\n"),

--- a/mdformat/renderer/_tree.py
+++ b/mdformat/renderer/_tree.py
@@ -291,6 +291,9 @@ class SyntaxTreeNode:
 
 
 class RenderContext(NamedTuple):
+    """A collection of data that needs to be passed to every `Renderer`
+    method."""
+
     renderers: Mapping[str, Renderer]
     postprocessors: Mapping[str, Iterable[Postprocessor]]
     options: Mapping[str, Any]
@@ -298,6 +301,8 @@ class RenderContext(NamedTuple):
 
 
 class RenderTreeNode(SyntaxTreeNode):
+    """A syntax tree node capable of making a text rendering of itself."""
+
     def render(self, context: RenderContext) -> str:
         renderer = context.renderers[self.type]
         text = renderer(self, context)

--- a/mdformat/renderer/_tree.py
+++ b/mdformat/renderer/_tree.py
@@ -14,7 +14,7 @@ from typing import (
 
 from markdown_it.token import Token
 
-from mdformat.renderer.typing import Postprocessor, Renderer
+from mdformat.renderer.typing import Postprocess, Render
 
 
 def _removesuffix(string: str, suffix: str) -> str:
@@ -294,8 +294,8 @@ class RenderContext(NamedTuple):
     """A collection of data that needs to be passed to every `Renderer`
     method."""
 
-    renderers: Mapping[str, Renderer]
-    postprocessors: Mapping[str, Iterable[Postprocessor]]
+    renderers: Mapping[str, Render]
+    postprocessors: Mapping[str, Iterable[Postprocess]]
     options: Mapping[str, Any]
     env: MutableMapping
 

--- a/mdformat/renderer/_tree.py
+++ b/mdformat/renderer/_tree.py
@@ -291,8 +291,8 @@ class SyntaxTreeNode:
 
 
 class RenderContext(NamedTuple):
-    """A collection of data that needs to be passed to every `Renderer`
-    method."""
+    """A collection of data that is passed as input to `Render` and
+    `Postprocess` functions."""
 
     renderers: Mapping[str, Render]
     postprocessors: Mapping[str, Iterable[Postprocess]]

--- a/mdformat/renderer/_tree.py
+++ b/mdformat/renderer/_tree.py
@@ -65,7 +65,7 @@ class SyntaxTreeNode:
             self._set_children_from_tokens(tokens)
             return
 
-        if not tokens:
+        if not tokens:  # pragma: no cover
             raise ValueError(
                 "Can only create root from empty token sequence."
                 " Set `create_root=True`."

--- a/mdformat/renderer/typing.py
+++ b/mdformat/renderer/typing.py
@@ -1,12 +1,17 @@
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
-    from mdformat.renderer import RenderContext, RenderTreeNode
+    from mdformat.renderer import RenderTreeNode
 
-
+# There should be `mdformat.renderer.RenderContext` instead of `Any`
+# here but that results in recursive typing which mypy doesn't support
+# until https://github.com/python/mypy/issues/731 is implemented.
 Renderer = Callable[
-    ["RenderTreeNode", "RenderContext"],
+    ["RenderTreeNode", Any],
     str,
 ]
 
-Postprocessor = Callable[[str, "RenderTreeNode", "RenderContext"], str]
+# There should be `mdformat.renderer.RenderContext` instead of `Any`
+# here but that results in recursive typing which mypy doesn't support
+# until https://github.com/python/mypy/issues/731 is implemented.
+Postprocessor = Callable[[str, "RenderTreeNode", Any], str]

--- a/mdformat/renderer/typing.py
+++ b/mdformat/renderer/typing.py
@@ -4,14 +4,12 @@ if TYPE_CHECKING:
     from mdformat.renderer import RenderTreeNode
 
 # There should be `mdformat.renderer.RenderContext` instead of `Any`
-# here but that results in recursive typing which mypy doesn't support
-# until https://github.com/python/mypy/issues/731 is implemented.
+# here and in `Postprocessor` below but that results in recursive typing
+# which mypy doesn't support until
+# https://github.com/python/mypy/issues/731 is implemented.
 Renderer = Callable[
     ["RenderTreeNode", Any],
     str,
 ]
 
-# There should be `mdformat.renderer.RenderContext` instead of `Any`
-# here but that results in recursive typing which mypy doesn't support
-# until https://github.com/python/mypy/issues/731 is implemented.
 Postprocessor = Callable[[str, "RenderTreeNode", Any], str]

--- a/mdformat/renderer/typing.py
+++ b/mdformat/renderer/typing.py
@@ -1,18 +1,12 @@
-from typing import TYPE_CHECKING, Any, Callable, Mapping, MutableMapping
+from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
-    from mdformat.renderer import RenderTreeNode
+    from mdformat.renderer import RenderContext, RenderTreeNode
 
 
-RendererFunc = Callable[
-    [
-        "RenderTreeNode",
-        # There is a recursion here. This should be
-        # `Mapping[str, RendererFunc],` but mypy doesn't support this until
-        # https://github.com/python/mypy/issues/731 is implemented.
-        Mapping[str, Callable[..., str]],
-        Mapping[str, Any],
-        MutableMapping,
-    ],
+Renderer = Callable[
+    ["RenderTreeNode", "RenderContext"],
     str,
 ]
+
+Postprocessor = Callable[[str, "RenderTreeNode", "RenderContext"], str]

--- a/mdformat/renderer/typing.py
+++ b/mdformat/renderer/typing.py
@@ -4,12 +4,12 @@ if TYPE_CHECKING:
     from mdformat.renderer import RenderTreeNode
 
 # There should be `mdformat.renderer.RenderContext` instead of `Any`
-# here and in `Postprocessor` below but that results in recursive typing
+# here and in `Postprocess` below but that results in recursive typing
 # which mypy doesn't support until
 # https://github.com/python/mypy/issues/731 is implemented.
-Renderer = Callable[
+Render = Callable[
     ["RenderTreeNode", Any],
     str,
 ]
 
-Postprocessor = Callable[[str, "RenderTreeNode", Any], str]
+Postprocess = Callable[[str, "RenderTreeNode", Any], str]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -231,7 +231,7 @@ class PrefixPostprocessPlugin:
     ) -> str:
         return "Prefixed!" + text
 
-    RENDERERS = {}
+    RENDERERS: dict = {}
     POSTPROCESSORS = {"text": _text_postprocess}
 
 
@@ -249,7 +249,7 @@ class SuffixPostprocessPlugin:
     ) -> str:
         return text + "Suffixed!"
 
-    RENDERERS = {}
+    RENDERERS: dict = {}
     POSTPROCESSORS = {"text": _text_postprocess}
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,7 +1,6 @@
 import argparse
 import json
 from textwrap import dedent
-from typing import Any, Mapping, MutableMapping
 from unittest.mock import patch
 
 from markdown_it import MarkdownIt
@@ -10,8 +9,7 @@ import pytest
 import mdformat
 from mdformat._cli import run
 from mdformat.plugins import CODEFORMATTERS, PARSER_EXTENSIONS
-from mdformat.renderer import MDRenderer, RenderTreeNode
-from mdformat.renderer.typing import RendererFunc
+from mdformat.renderer import MDRenderer, RenderContext, RenderTreeNode
 
 
 def example_formatter(code, info):
@@ -47,14 +45,11 @@ class TextEditorPlugin:
         pass
 
     def _text_renderer(  # type: ignore
-        tree: RenderTreeNode,
-        renderer_funcs: Mapping[str, RendererFunc],
-        options: Mapping[str, Any],
-        env: MutableMapping,
+        tree: RenderTreeNode, context: RenderContext
     ) -> str:
         return "All text is like this now!"
 
-    RENDERER_FUNCS = {"text": _text_renderer}
+    RENDERERS = {"text": _text_renderer}
 
 
 def test_single_token_extension(monkeypatch):
@@ -88,14 +83,11 @@ class ExampleTablePlugin:
         mdit.enable("table")
 
     def _table_renderer(  # type: ignore
-        tree: RenderTreeNode,
-        renderer_funcs: Mapping[str, RendererFunc],
-        options: Mapping[str, Any],
-        env: MutableMapping,
+        tree: RenderTreeNode, context: RenderContext
     ) -> str:
         return "dummy 21"
 
-    RENDERER_FUNCS = {"table": _table_renderer}
+    RENDERERS = {"table": _table_renderer}
 
 
 def test_table(monkeypatch):
@@ -167,14 +159,11 @@ class ExampleASTChangingPlugin:
         pass
 
     def _text_renderer(  # type: ignore
-        tree: RenderTreeNode,
-        renderer_funcs: Mapping[str, RendererFunc],
-        options: Mapping[str, Any],
-        env: MutableMapping,
+        tree: RenderTreeNode, context: RenderContext
     ) -> str:
         return ExampleASTChangingPlugin.TEXT_REPLACEMENT
 
-    RENDERER_FUNCS = {"text": _text_renderer}
+    RENDERERS = {"text": _text_renderer}
 
 
 def test_ast_changing_plugin(monkeypatch, tmp_path):


### PR DESCRIPTION
One possible solution to https://github.com/executablebooks/mdformat/issues/174