### PR TITLE
FIX: Dont error when an autolink contains spaces

### DIFF
--- a/docs/users/changelog.md
+++ b/docs/users/changelog.md
@@ -3,6 +3,12 @@
 This log documents all Python API or CLI breaking backwards incompatible changes.
 Note that there is currently no guarantee for a stable Markdown formatting style across versions.
 
+## 0.7.9
+
+- Fixed
+  - Fix an error when an autolink contains URL encoded spaces.
+    Thank you [Chris Butler](https://github.com/butler54) for the issue.
+
 ## 0.7.8
 
 - Fixed

--- a/src/mdformat/renderer/_context.py
+++ b/src/mdformat/renderer/_context.py
@@ -247,6 +247,7 @@ def _render_inline_as_text(node: "RenderTreeNode", context: "RenderContext") -> 
 def link(node: "RenderTreeNode", context: "RenderContext") -> str:
     if node.info == "auto":
         autolink_url = node.attrs["href"]
+        assert isinstance(autolink_url, str)
         # The parser adds a "mailto:" prefix to autolink email href. We remove the
         # prefix if it wasn't there in the source.
         if autolink_url.startswith("mailto:") and not node.children[

--- a/src/mdformat/renderer/_context.py
+++ b/src/mdformat/renderer/_context.py
@@ -245,14 +245,21 @@ def _render_inline_as_text(node: "RenderTreeNode", context: "RenderContext") -> 
 
 
 def link(node: "RenderTreeNode", context: "RenderContext") -> str:
+    if node.info == "auto":
+        autolink_url = node.attrs["href"]
+        # The parser adds a "mailto:" prefix to autolink email href. We remove the
+        # prefix if it wasn't there in the source.
+        if autolink_url.startswith("mailto:") and not node.children[
+            0
+        ].content.startswith("mailto:"):
+            autolink_url = autolink_url[7:]
+        return "<" + autolink_url + ">"
+
     text = "".join(child.render(context) for child in node.children)
 
     if context.do_wrap:
         # Prevent line breaks
         text = text.replace(WRAP_POINT, " ")
-
-    if node.info == "auto":
-        return "<" + text + ">"
 
     ref_label = node.meta.get("label")
     if ref_label:

--- a/tests/data/default_style.md
+++ b/tests/data/default_style.md
@@ -367,3 +367,17 @@ Indented raw HTML contains Markdown
 
 </center>
 .
+
+Autolink with percentage encoded space
+.
+<https://mytest.com/files/word%20document.docx>
+.
+<https://mytest.com/files/word%20document.docx>
+.
+
+Keep mailto: prefix in autolink
+.
+<MAILTO:FOO@BAR.BAZ>>
+.
+<mailto:FOO@BAR.BAZ>>
+.

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -4,23 +4,27 @@ from markdown_it.utils import read_fixture_file
 import pytest
 
 import mdformat
-from mdformat.renderer._util import CONSECUTIVE_KEY
+import mdformat._cli
 
 
 @pytest.mark.parametrize(
     "fixture_file,options",
     [
-        ("default_style.md", {}),
-        ("consecutive_numbering.md", {CONSECUTIVE_KEY: True}),
-        ("wrap_width_50.md", {"wrap": 50}),
+        ("default_style.md", []),
+        ("consecutive_numbering.md", ["--number"]),
+        ("wrap_width_50.md", ["--wrap=50"]),
     ],
 )
-def test_style(fixture_file, options):
+def test_style(fixture_file, options, tmp_path):
     """Test Markdown renderer renders expected style."""
+    file_path = tmp_path / "test_markdown.md"
     cases = read_fixture_file(Path(__file__).parent / "data" / fixture_file)
     for case in cases:
         line, title, text, expected = case
-        md_new = mdformat.text(text, options=options)
+        file_path.write_text(text)
+        assert mdformat._cli.run([str(file_path), *options]) == 0
+        md_new = file_path.read_text()
         if md_new != expected:
+            print("Formatted (unexpected) Markdown below:")
             print(md_new)
         assert md_new == expected

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -21,9 +21,9 @@ def test_style(fixture_file, options, tmp_path):
     cases = read_fixture_file(Path(__file__).parent / "data" / fixture_file)
     for case in cases:
         line, title, text, expected = case
-        file_path.write_text(text)
+        file_path.write_bytes(text.encode())
         assert mdformat._cli.run([str(file_path), *options]) == 0
-        md_new = file_path.read_text()
+        md_new = file_path.read_bytes().decode()
         if md_new != expected:
             print("Formatted (unexpected) Markdown below:")
             print(md_new)


### PR DESCRIPTION
Partially fixes https://github.com/executablebooks/mdformat/issues/254