### PR TITLE
Fix needlessly indenting type 7 inline HTML

### DIFF
--- a/docs/users/changelog.md
+++ b/docs/users/changelog.md
@@ -3,6 +3,12 @@
 This log documents all Python API or CLI breaking backwards incompatible changes.
 Note that there is currently no guarantee for a stable Markdown formatting style across versions.
 
+## 0.7.13
+
+- Fixed
+  - Don't indent inline HTML that looks like type 7 block HTML.
+    Thank you [Philip May](https://github.com/PhilipMay) for the issue.
+
 ## 0.7.12
 
 - Fixed

--- a/src/mdformat/renderer/_context.py
+++ b/src/mdformat/renderer/_context.py
@@ -438,8 +438,10 @@ def paragraph(node: RenderTreeNode, context: RenderContext) -> str:  # noqa: C90
 
         # Check if the line could be interpreted as an HTML block.
         # If yes, prefix it with 4 spaces to prevent this.
-        for html_seq in HTML_SEQUENCES:
-            if html_seq[0].search(lines[i]):
+        for html_seq_tuple in HTML_SEQUENCES:
+            can_break_paragraph = html_seq_tuple[2]
+            opening_re = html_seq_tuple[0]
+            if can_break_paragraph and opening_re.search(lines[i]):
                 lines[i] = f"    {lines[i]}"
                 break
 

--- a/tests/data/default_style.md
+++ b/tests/data/default_style.md
@@ -419,3 +419,14 @@ A
 
 <div>
 .
+
+Keep HTML blocks of type 7 unindented (they do not interrupt a paragraph)
+.
+text
+<br/>
+text
+.
+text
+<br/>
+text
+.


### PR DESCRIPTION
Closes https://github.com/executablebooks/mdformat/issues/296