### PR TITLE
renderers as parameters

### DIFF
--- a/src/mdformat/renderer/__init__.py
+++ b/src/mdformat/renderer/__init__.py
@@ -19,7 +19,7 @@ from markdown_it.token import Token
 
 from mdformat.renderer._context import DEFAULT_RENDERERS, WRAP_POINT, RenderContext
 from mdformat.renderer._tree import RenderTreeNode
-from mdformat.renderer.typing import Postprocess
+from mdformat.renderer.typing import Postprocess, Render
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/mdformat/renderer/__init__.py
+++ b/src/mdformat/renderer/__init__.py
@@ -62,6 +62,7 @@ class MDRenderer:
         options: Mapping[str, Any],
         env: MutableMapping,
         *,
+        renderers: Mapping[str, Render] = DEFAULT_RENDERERS,
         finalize: bool = True,
     ) -> str:
         self._prepare_env(env)
@@ -84,7 +85,7 @@ class MDRenderer:
                     postprocessors[syntax_name] = (pp,)
                 else:
                     postprocessors[syntax_name] += (pp,)
-        renderer_map = MappingProxyType({**DEFAULT_RENDERERS, **updated_renderers})
+        renderer_map = MappingProxyType({**renderers, **updated_renderers})
         postprocessor_map = MappingProxyType(postprocessors)
 
         render_context = RenderContext(renderer_map, postprocessor_map, options, env)


### PR DESCRIPTION
I would like to add a plaintext renderer that works out of the box with all the plugins/extensions. I would like a generic render_tree function for this (which the current one is not, as it adds newlines -- but that is alright with me).

My approach would be to add renderers as a parameter, so other projects can provide a different set of default rules. Alternatively one could set the default to `None` and then assign `DEFAULT_RENDERERS` later. While this is cleaner, the type signature would have to account for this `Union[Mapping[str, Render], NoneType]`.

Alternatively I would duplicate the whole function or would write a renderer class with methods for all the token types of all the plugins.