### PR TITLE
add option `end-of-line: keep`

### DIFF
--- a/docs/users/configuration_file.md
+++ b/docs/users/configuration_file.md
@@ -19,5 +19,5 @@ Command line interface arguments take precedence over the configuration file.
 #
 wrap = "keep"       # possible values: {"keep", "no", INTEGER}
 number = false      # possible values: {false, true}
-end_of_line = "lf"  # possible values: {"lf", "crlf"}
+end_of_line = "lf"  # possible values: {"lf", "crlf", "keep"}
 ```

--- a/src/mdformat/_api.py
+++ b/src/mdformat/_api.py
@@ -7,7 +7,13 @@ from pathlib import Path
 from typing import Any
 
 from mdformat._conf import DEFAULT_OPTS
-from mdformat._util import EMPTY_MAP, NULL_CTX, atomic_write, build_mdit
+from mdformat._util import (
+    EMPTY_MAP,
+    NULL_CTX,
+    atomic_write,
+    build_mdit,
+    detect_newline_type,
+)
 from mdformat.renderer import MDRenderer
 
 
@@ -58,7 +64,7 @@ def file(
     if f.is_symlink():
         raise ValueError(f'Cannot format "{f}". It is a symlink.')
 
-    original_md = f.read_text(encoding="utf-8")
+    original_md = f.read_bytes().decode()
     formatted_md = text(
         original_md,
         options=options,
@@ -66,9 +72,7 @@ def file(
         codeformatters=codeformatters,
         _filename=str(f),
     )
-    newline = (
-        "\r\n"
-        if options.get("end_of_line", DEFAULT_OPTS["end_of_line"]) == "crlf"
-        else "\n"
+    newline = detect_newline_type(
+        original_md, options.get("end_of_line", DEFAULT_OPTS["end_of_line"])
     )
     atomic_write(f, formatted_md, newline)

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -14,7 +14,7 @@ import textwrap
 import mdformat
 from mdformat._compat import importlib_metadata
 from mdformat._conf import DEFAULT_OPTS, InvalidConfError, read_toml_opts
-from mdformat._util import atomic_write, is_md_equal
+from mdformat._util import atomic_write, detect_newline_type, is_md_equal
 import mdformat.plugins
 import mdformat.renderer
 
@@ -112,7 +112,7 @@ def run(cli_args: Sequence[str]) -> int:  # noqa: C901
                     ],
                 )
                 return 1
-            newline = "\r\n" if opts["end_of_line"] == "crlf" else "\n"
+            newline = detect_newline_type(original_str, opts["end_of_line"])
             if path:
                 atomic_write(path, formatted_str, newline)
             else:
@@ -167,7 +167,7 @@ def make_arg_parser(
     )
     parser.add_argument(
         "--end-of-line",
-        choices=("lf", "crlf"),
+        choices=("lf", "crlf", "keep"),
         help="output file line ending mode (default: lf)",
     )
     for plugin in parser_extensions.values():

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -60,7 +60,7 @@ def run(cli_args: Sequence[str]) -> int:  # noqa: C901
         except InvalidConfError as e:
             print_error(str(e))
             return 1
-        opts = {**DEFAULT_OPTS, **toml_opts, **cli_opts}
+        opts: Mapping = {**DEFAULT_OPTS, **toml_opts, **cli_opts}
 
         if path:
             path_str = str(path)

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -81,16 +81,14 @@ def run(cli_args: Sequence[str]) -> int:  # noqa: C901
             ),
             _filename=path_str,
         )
+        newline = detect_newline_type(original_str, opts["end_of_line"])
 
         if opts["check"]:
             original_str_lf_eol = original_str.replace("\r\n", "\n").replace("\r", "\n")
             if (
                 (formatted_str != original_str_lf_eol)
-                or (opts["end_of_line"] == "lf" and "\r" in original_str)
-                or (
-                    opts["end_of_line"] == "crlf"
-                    and RE_NON_CRLF_LINE_END.search(original_str)
-                )
+                or (newline == "\n" and "\r" in original_str)
+                or (newline == "\r\n" and RE_NON_CRLF_LINE_END.search(original_str))
             ):
                 format_errors_found = True
                 print_error(f'File "{path_str}" is not formatted.')
@@ -112,7 +110,6 @@ def run(cli_args: Sequence[str]) -> int:  # noqa: C901
                     ],
                 )
                 return 1
-            newline = detect_newline_type(original_str, opts["end_of_line"])
             if path:
                 atomic_write(path, formatted_str, newline)
             else:

--- a/src/mdformat/_conf.py
+++ b/src/mdformat/_conf.py
@@ -53,7 +53,7 @@ def _validate_values(opts: Mapping, conf_path: Path) -> None:
         ):
             raise InvalidConfError(f"Invalid 'wrap' value in {conf_path}")
     if "end_of_line" in opts:
-        if opts["end_of_line"] not in {"crlf", "lf"}:
+        if opts["end_of_line"] not in {"crlf", "lf", "keep"}:
             raise InvalidConfError(f"Invalid 'end_of_line' value in {conf_path}")
     if "number" in opts:
         if not isinstance(opts["number"], bool):

--- a/src/mdformat/_util.py
+++ b/src/mdformat/_util.py
@@ -117,7 +117,7 @@ def atomic_write(path: Path, text: str, newline: str) -> None:
         raise
 
 
-def detect_newline_type(md: str, eol_setting) -> Literal["\n", "\r\n"]:
+def detect_newline_type(md: str, eol_setting: str) -> Literal["\n", "\r\n"]:
     """Returns the newline-character to be used for output.
 
     If `eol_setting == "keep"`, the newline character used in the passed

--- a/src/mdformat/_util.py
+++ b/src/mdformat/_util.py
@@ -127,10 +127,7 @@ def detect_newline_type(md: str, eol_setting: str) -> Literal["\n", "\r\n"]:
     """
     if eol_setting == "keep":
         first_eol = RE_NEWLINES.search(md)
-        if first_eol is None:
-            return "\n"
-        char = first_eol.group()
-        return "\n" if char == "\r" else char
+        return "\r\n" if first_eol and first_eol.group() == "\r\n" else "\n"
     if eol_setting == "crlf":
         return "\r\n"
     return "\n"

--- a/src/mdformat/_util.py
+++ b/src/mdformat/_util.py
@@ -7,7 +7,8 @@ from pathlib import Path
 import re
 import tempfile
 from types import MappingProxyType
-from typing import Any, Literal
+from typing import Any
+from mdformat._compat import Literal
 
 from markdown_it import MarkdownIt
 from markdown_it.renderer import RendererHTML

--- a/src/mdformat/_util.py
+++ b/src/mdformat/_util.py
@@ -8,11 +8,11 @@ import re
 import tempfile
 from types import MappingProxyType
 from typing import Any
-from mdformat._compat import Literal
 
 from markdown_it import MarkdownIt
 from markdown_it.renderer import RendererHTML
 
+from mdformat._compat import Literal
 import mdformat.plugins
 
 NULL_CTX = nullcontext()

--- a/src/mdformat/_util.py
+++ b/src/mdformat/_util.py
@@ -118,7 +118,7 @@ def atomic_write(path: Path, text: str, newline: str) -> None:
 
 
 def detect_newline_type(md: str, eol_setting) -> Literal["\n", "\r\n"]:
-    """Retruns the newline-character to be used for output.
+    """Returns the newline-character to be used for output.
 
     If `eol_setting`=="keep", the newline character used in the passed
     markdown is detected and returned. Otherwise the character matching

--- a/src/mdformat/_util.py
+++ b/src/mdformat/_util.py
@@ -120,7 +120,7 @@ def atomic_write(path: Path, text: str, newline: str) -> None:
 def detect_newline_type(md: str, eol_setting) -> Literal["\n", "\r\n"]:
     """Returns the newline-character to be used for output.
 
-    If `eol_setting`=="keep", the newline character used in the passed
+    If `eol_setting == "keep"`, the newline character used in the passed
     markdown is detected and returned. Otherwise the character matching
     the passed setting is returned.
     """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -93,3 +93,17 @@ def test_eol__crlf(tmp_path):
     file_path.write_bytes(b"Oi\n")
     mdformat.file(str(file_path), options={"end_of_line": "crlf"})
     assert file_path.read_bytes() == b"Oi\r\n"
+
+
+def test_eol__keep_lf(tmp_path):
+    file_path = tmp_path / "test.md"
+    file_path.write_bytes(b"Oi\n")
+    mdformat.file(str(file_path), options={"end_of_line": "keep"})
+    assert file_path.read_bytes() == b"Oi\n"
+
+
+def test_eol__keep_crlf(tmp_path):
+    file_path = tmp_path / "test.md"
+    file_path.write_bytes(b"Oi\r\n")
+    mdformat.file(str(file_path), options={"end_of_line": "keep"})
+    assert file_path.read_bytes() == b"Oi\r\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -251,6 +251,20 @@ def test_eol__crlf(tmp_path):
     assert file_path.read_bytes() == b"Oi\r\n"
 
 
+def test_eol__keep_lf(tmp_path):
+    file_path = tmp_path / "test.md"
+    file_path.write_bytes(b"Oi\n")
+    assert run([str(file_path), "--end-of-line=keep"]) == 0
+    assert file_path.read_bytes() == b"Oi\n"
+
+
+def test_eol__keep_crlf(tmp_path):
+    file_path = tmp_path / "test.md"
+    file_path.write_bytes(b"Oi\r\n")
+    assert run([str(file_path), "--end-of-line=keep"]) == 0
+    assert file_path.read_bytes() == b"Oi\r\n"
+
+
 def test_eol__crlf_stdin(capfd, monkeypatch):
     monkeypatch.setattr(sys, "stdin", StringIO("Oi\n"))
     assert run(["-", "--end-of-line=crlf"]) == 0
@@ -276,6 +290,18 @@ def test_eol__check_crlf(tmp_path):
 
     file_path.write_bytes(b"lol\r\n")
     assert run((str(file_path), "--check", "--end-of-line=crlf")) == 0
+
+
+def test_eol__check_keep_lf(tmp_path):
+    file_path = tmp_path / "test.md"
+    file_path.write_bytes(b"lol\n")
+    assert run((str(file_path), "--check", "--end-of-line=keep")) == 0
+
+
+def test_eol__check_keep_crlf(tmp_path):
+    file_path = tmp_path / "test.md"
+    file_path.write_bytes(b"lol\r\n")
+    assert run((str(file_path), "--check", "--end-of-line=keep")) == 0
 
 
 def test_get_package_name():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -294,14 +294,22 @@ def test_eol__check_crlf(tmp_path):
 
 def test_eol__check_keep_lf(tmp_path):
     file_path = tmp_path / "test.md"
+
     file_path.write_bytes(b"lol\n")
     assert run((str(file_path), "--check", "--end-of-line=keep")) == 0
+
+    file_path.write_bytes(b"mixed\nEOLs\r")
+    assert run((str(file_path), "--check", "--end-of-line=keep")) == 1
 
 
 def test_eol__check_keep_crlf(tmp_path):
     file_path = tmp_path / "test.md"
+
     file_path.write_bytes(b"lol\r\n")
     assert run((str(file_path), "--check", "--end-of-line=keep")) == 0
+
+    file_path.write_bytes(b"mixed\r\nEOLs\n")
+    assert run((str(file_path), "--check", "--end-of-line=keep")) == 1
 
 
 def test_get_package_name():


### PR DESCRIPTION
as discussed in #336 

The new option option `--end-of-line=keep` will not attempt to change line-endings, instead it will infer the type of lineedning from the first line of the file and continue using that.

---

not jet complete, it failes on `crlf` lineendings when using `--check`, as the `formated_str` will have the new-line-characters replaced and not equal `original_str`, therefor "correctly" failing. I could of course skip the `opts["check"]` block, but that feels really wrong.

any suggestions?
