### PR TITLE
FIX: An empty paragraph (Unicode space only) triggers AST check

### DIFF
--- a/src/mdformat/_util.py
+++ b/src/mdformat/_util.py
@@ -89,9 +89,14 @@ def is_md_equal(
         html = html.replace("<p> ", "<p>")
         html = html.replace(" </p>", "</p>")
 
+        # Also strip whitespace leading/trailing the <p> elements so that we can
+        # safely remove empty paragraphs below without introducing extra whitespace.
+        html = html.replace(" <p>", "<p>")
+        html = html.replace("</p> ", "</p>")
+
         # empty p elements should be ignored by user agents
         # (https://www.w3.org/TR/REC-html40/struct/text.html#edef-P)
-        html = re.sub(r" ?<p></p> ?", "", html)
+        html = html.replace("<p></p>", "")
 
         # If it's nothing but whitespace, it's equal
         html = re.sub(r"^\s+$", "", html)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,14 +42,16 @@ def test_fmt_string():
     assert mdformat.text(UNFORMATTED_MARKDOWN) == FORMATTED_MARKDOWN
 
 
-def test_vertical_tab_only():
-    input_ = "\x0b"
-    output = mdformat.text(input_)
-    assert is_md_equal(input_, output)
-
-
-def test_no_codeblock_trailing_newline():
-    input_ = "\t##"
+@pytest.mark.parametrize(
+    "input_",
+    [
+        pytest.param("\x0b"),  # vertical tab only
+        pytest.param("\t##"),  # no trailing newline in codeblock
+        pytest.param("a\n\n\xa0\n\nb"),  # lone NBSP between two paragraphs
+        pytest.param("\xa0\n\n# heading"),  # lone NBSP followed by a heading
+    ],
+)
+def test_output_is_equal(input_):
     output = mdformat.text(input_)
     assert is_md_equal(input_, output)
 


### PR DESCRIPTION
Fixes https://github.com/executablebooks/mdformat/issues/351