### PR TITLE
Add shell completions by shtab

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,11 @@ classifiers = [
 ]
 keywords = ["mdformat", "markdown", "commonmark", "formatter", "pre-commit"]
 
+[project.optional-dependencies]
+completion = [
+    "shtab",
+]
+
 [project.urls]
 "Homepage" = "https://github.com/executablebooks/mdformat"
 "Documentation" = "https://mdformat.readthedocs.io"

--- a/src/mdformat/_shtab.py
+++ b/src/mdformat/_shtab.py
@@ -1,0 +1,10 @@
+from argparse import Action, ArgumentParser
+from typing import Any, Dict, List
+
+FILE = None
+DIRECTORY = DIR = None
+
+
+def add_argument_to(parser: ArgumentParser, *args: List[Any], **kwargs: Dict[str, Any]):
+    Action.complete = None
+    return parser


### PR DESCRIPTION
```sh
mdformat --print-completion bash | sudo tee /usr/share/bash-completion/completions/mdformat
mdformat --print-completion zsh | sudo tee /usr/share/zsh/site-functions/_mdformat
mdformat --print-completion tcsh | sudo tee /etc/profile.d/mdformat.completion.csh
```

```sh
❯ mdformat --<TAB>
option
--check              do not apply changes to files
--end-of-line        output file line ending mode (default: lf)
--help               show this help message and exit
-h                   show this help message and exit
--number             apply consecutive numbering to ordered lists
--print-completion   print shell completion script
--version            show program's version number and exit
--wrap               paragraph word wrap mode (default: keep)
❯ mdformat --end-of-line <TAB>
end_of_line
crlf  keep  lf
```