### PR TITLE
docs: add mdformat-mkdocs

### DIFF
--- a/docs/users/plugins.md
+++ b/docs/users/plugins.md
@@ -94,6 +94,26 @@ formatted = mdformat.text(unformatted, extensions={"tables"})
     <th>Description</th>
   </tr>
   <tr>
+    <td><a href="https://github.com/KyleKing/mdformat-admon">mdformat-admon</a></td>
+    <td><code>admonition</code></td>
+    <td>Adds support for <a href="https://python-markdown.github.io/extensions/admonition/">python-markdown</a> admonitions</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/executablebooks/mdformat-deflist">mdformat-deflist</a></td>
+    <td><code>deflist</code></td>
+    <td>Adds support for <a href="https://pandoc.org/MANUAL.html#definition-lists">Pandoc-style</a> definition lists</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/executablebooks/mdformat-footnote">mdformat-footnote</a></td>
+    <td><code>footnote</code></td>
+    <td>Adds support for <a href="https://pandoc.org/MANUAL.html#footnotes">Pandoc-style</a> footnotes</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/butler54/mdformat-frontmatter">mdformat-frontmatter</a></td>
+    <td><code>frontmatter</code></td>
+    <td>Adds support for front matter, and formats YAML front matter</td>
+  </tr>
+  <tr>
     <td><a href="https://github.com/hukkin/mdformat-gfm">mdformat-gfm</a></td>
     <td><code>gfm</code></td>
     <td>Changes target specification to GitHub Flavored Markdown (GFM)</td>
@@ -117,25 +137,5 @@ formatted = mdformat.text(unformatted, extensions={"tables"})
     <td><a href="https://github.com/hukkin/mdformat-toc">mdformat-toc</a></td>
     <td><code>toc</code></td>
     <td>Adds the capability to auto-generate a table of contents</td>
-  </tr>
-  <tr>
-    <td><a href="https://github.com/executablebooks/mdformat-footnote">mdformat-footnote</a></td>
-    <td><code>footnote</code></td>
-    <td>Adds support for <a href="https://pandoc.org/MANUAL.html#footnotes">Pandoc-style</a> footnotes</td>
-  </tr>
-  <tr>
-    <td><a href="https://github.com/butler54/mdformat-frontmatter">mdformat-frontmatter</a></td>
-    <td><code>frontmatter</code></td>
-    <td>Adds support for front matter, and formats YAML front matter</td>
-  </tr>
-  <tr>
-    <td><a href="https://github.com/executablebooks/mdformat-deflist">mdformat-deflist</a></td>
-    <td><code>deflist</code></td>
-    <td>Adds support for <a href="https://pandoc.org/MANUAL.html#definition-lists">Pandoc-style</a> definition lists</td>
-  </tr>
-  <tr>
-    <td><a href="https://github.com/KyleKing/mdformat-admon">mdformat-admon</a></td>
-    <td><code>admonition</code></td>
-    <td>Adds support for <a href="https://python-markdown.github.io/extensions/admonition/">python-markdown</a> admonitions</td>
   </tr>
 </table>

--- a/docs/users/plugins.md
+++ b/docs/users/plugins.md
@@ -121,7 +121,7 @@ formatted = mdformat.text(unformatted, extensions={"tables"})
   <tr>
     <td><a href="https://github.com/KyleKing/mdformat-mkdocs">mdformat-mkdocs</a></td>
     <td><code>mkdocs</code></td>
-    <td>Changes target specification to MKDocs to use 4-spaces instead of 2 for indents</td>
+    <td>Changes target specification to MKDocs. Indents lists with 4-spaces instead of 2</td>
   </tr>
   <tr>
     <td><a href="https://github.com/executablebooks/mdformat-myst">mdformat-myst</a></td>

--- a/docs/users/plugins.md
+++ b/docs/users/plugins.md
@@ -99,6 +99,11 @@ formatted = mdformat.text(unformatted, extensions={"tables"})
     <td>Changes target specification to GitHub Flavored Markdown (GFM)</td>
   </tr>
   <tr>
+    <td><a href="https://github.com/KyleKing/mdformat-mkdocs">mdformat-mkdocs</a></td>
+    <td><code>mkdocs</code></td>
+    <td>Changes target specification to MKDocs to use 4-spaces instead of 2 for indents</td>
+  </tr>
+  <tr>
     <td><a href="https://github.com/executablebooks/mdformat-myst">mdformat-myst</a></td>
     <td><code>myst</code></td>
     <td>Changes target specification to <a href="https://myst-parser.readthedocs.io/en/latest/using/syntax.html">MyST</a></td>


### PR DESCRIPTION
I finally finished [mdformat-mkdocs](https://github.com/KyleKing/mdformat-mkdocs) that formats list indents to 4-spaces

Fixes: #317, #331, #371

I also went ahead and sorted the plugins: https://github.com/executablebooks/mdformat/pull/375#discussion_r1051674629 in https://github.com/executablebooks/mdformat/pull/380/commits/eb68659c0271ed4a8100ccacdce1954bfc1f8366