### PR TITLE
Add exclude option to cli and configuration toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
   hooks:
   - id: absolufy-imports
 - repo: https://github.com/PyCQA/isort
-  rev: c5e8fa75dda5f764d20f66a215d71c21cfa198e1  # frozen: 5.10.1
+  rev: e44834b7b294701f596c9118d6c370f86671a50d  # frozen: 5.12.0
   hooks:
   - id: isort
 - repo: https://github.com/psf/black

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -62,6 +62,9 @@ def run(cli_args: Sequence[str]) -> int:  # noqa: C901
             return 1
         opts: Mapping = {**DEFAULT_OPTS, **toml_opts, **cli_opts}
 
+        if _is_excluded(path, opts["exclude"]):
+            continue
+
         if path:
             path_str = str(path)
             # Unlike `path.read_text(encoding="utf-8")`, this preserves
@@ -143,6 +146,7 @@ def make_arg_parser(
         else None,
     )
     parser.add_argument("paths", nargs="*", help="files to format")
+    parser.add_argument("--exclude", nargs="*", help="files to ignore")
     parser.add_argument(
         "--check", action="store_true", help="do not apply changes to files"
     )
@@ -217,6 +221,10 @@ def _resolve_path(path: Path) -> Path:
     if not path_exists:
         raise InvalidPath(path)
     return path
+
+
+def _is_excluded(file_path: Path, exclude_strings: Iterable[str]) -> bool:
+    return any(file_path.match(exclude_string) for exclude_string in exclude_strings)
 
 
 def print_paragraphs(paragraphs: Iterable[str]) -> None:

--- a/src/mdformat/_conf.py
+++ b/src/mdformat/_conf.py
@@ -10,6 +10,7 @@ DEFAULT_OPTS = {
     "wrap": "keep",
     "number": False,
     "end_of_line": "lf",
+    "exclude": [],
 }
 
 
@@ -58,6 +59,9 @@ def _validate_values(opts: Mapping, conf_path: Path) -> None:
     if "number" in opts:
         if not isinstance(opts["number"], bool):
             raise InvalidConfError(f"Invalid 'number' value in {conf_path}")
+    if "exclude" in opts:
+        if not isinstance(opts["exclude"], list):
+            raise InvalidConfError(f"Invalid 'exclude' value in {conf_path}")
 
 
 def _validate_keys(opts: Mapping, conf_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,6 +70,36 @@ def test_invalid_file(capsys):
     assert "does not exist" in captured.err
 
 
+def test_exclude(tmp_path):
+    file_path_1 = tmp_path / "test_markdown1.md"
+    file_path_2 = tmp_path / "test_markdown2.md"
+    file_path_3 = tmp_path / "test_markdown3.md"
+    subdir_path = tmp_path / "subdir"
+    subdir_path.mkdir()
+    file_path_4 = subdir_path / "test_markdown4.md"
+    file_path_1.write_text(UNFORMATTED_MARKDOWN)
+    file_path_2.write_text(UNFORMATTED_MARKDOWN)
+    file_path_3.write_text(UNFORMATTED_MARKDOWN)
+    file_path_4.write_text(UNFORMATTED_MARKDOWN)
+    assert (
+        run(
+            [
+                str(tmp_path),
+                "--exclude",
+                "test_markdown3.md",
+                "*2.md",
+                "subdir/*",
+                "abc.md",
+            ]
+        )
+        == 0
+    )
+    assert file_path_1.read_text() == FORMATTED_MARKDOWN
+    assert file_path_2.read_text() == UNFORMATTED_MARKDOWN
+    assert file_path_3.read_text() == UNFORMATTED_MARKDOWN
+    assert file_path_4.read_text() == UNFORMATTED_MARKDOWN
+
+
 def test_check(tmp_path):
     file_path = tmp_path / "test_markdown.md"
     file_path.write_bytes(FORMATTED_MARKDOWN.encode())

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -65,6 +65,7 @@ def test_invalid_toml(tmp_path, capsys):
         ("wrap", "wrap = -3"),
         ("end_of_line", "end_of_line = 'lol'"),
         ("number", "number = 0"),
+        ("exclude", "exclude = 'lol'"),
     ],
 )
 def test_invalid_conf_value(bad_conf, conf_key, tmp_path, capsys):


### PR DESCRIPTION
PR adds an `exclude` option to the CLI (and to the configuration TOML) for excluding files matching the specified patterns. This provides a way to run `mdformat` outside of pre-commit but still with the ability to exclude certain files.

Resolves #359 