### PR TITLE
Don't change file permissions when fixing the format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
   hooks:
   - id: absolufy-imports
 - repo: https://github.com/PyCQA/isort
-  rev: c5e8fa75dda5f764d20f66a215d71c21cfa198e1  # frozen: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
 - repo: https://github.com/psf/black

--- a/src/mdformat/_util.py
+++ b/src/mdformat/_util.py
@@ -116,6 +116,10 @@ def atomic_write(path: Path, text: str, newline: str) -> None:
     """
     fd, tmp_path = tempfile.mkstemp(dir=path.parent)
     try:
+        # Set the same permission as the original file.
+        stat = os.stat(path)
+        os.chmod(tmp_path, stat.st_mode)
+
         with open(fd, "w", encoding="utf-8", newline=newline) as f:
             f.write(text)
         if filecmp.cmp(tmp_path, path, shallow=False):


### PR DESCRIPTION
When mdformat formats a file, the current mdformat also changes the permission of the file to `600` because it creates a temporary file with `mkstemp` that creates a file with `600`.
This PR set the original file permission not to modify file permissions.