### PR TITLE
Added `mdformat-gfm-alerts` to GitHub full installation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Note that GitHub's Markdown renderer supports syntax extensions not included in 
 For full GitHub support do:
 
 ```bash
-pip install mdformat-gfm mdformat-frontmatter mdformat-footnote
+pip install mdformat-gfm mdformat-frontmatter mdformat-footnote mdformat-gfm-alerts
 ```
 
 Install with [Markedly Structured Text (MyST)](https://myst-parser.readthedocs.io/en/latest/using/syntax.html) support:


### PR DESCRIPTION
The documentation declares a list of packages that should be installed to enable full GitHub-flavored support. However, the list does not include the `mdformat-gfm-alerts` packages that adds support to alerts, which are not supported by any other package in the existing list.