### PR TITLE
🔧 MAINTAIN: Resolve CI Failures

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,3 +4,5 @@ max-complexity = 10
 # These checks violate PEP8 so let's ignore them
 extend-ignore = E203
 extend-exclude = */site-packages/*
+per-file-ignores =
+    src/mdformat/renderer/typing.py:A005

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,12 +5,28 @@
 # Required
 version: 2
 
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-lts-latest
+  tools:
+    python: "3.12"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   fail_on_warning: true
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  fail_on_warning: true
 
-# Optionally set the version of Python and requirements required to build your docs
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#   - pdf
+#   - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
-   version: '3.8'
-   install:
-   - requirements: docs/requirements.txt
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
Update the RTD configuration to include the now required `build.os` setting: https://github.com/readthedocs/readthedocs.org/blob/2f48c81e9ce162bbd34229e897db84044b00fe31/docs/user/config-file/v2.rst#buildos

And to address the pre-commit/flake8 error, we need to add an ignore rule because renaming the file to resolve the warning would be breaking (e.g. https://github.com/executablebooks/mdformat-deflist/blob/919cc85cf8c750fd74550b65fa2a2a7728ca6628/mdformat_deflist/plugin.py#L5)

Merging this PR will unblock the open documentation PRs (#425, #418, #440, #427)