### PR TITLE
New plugin API for adding CLI options. Let plugins add corresponding TOML conf

### DIFF
--- a/docs/users/changelog.md
+++ b/docs/users/changelog.md
@@ -3,6 +3,17 @@
 This log documents all Python API or CLI breaking backwards incompatible changes.
 Note that there is currently no guarantee for a stable Markdown formatting style across versions.
 
+## 0.7.19
+
+- Deprecated
+  - Plugin interface: `mdformat.plugins.ParserExtensionInterface.add_cli_options`.
+    The replacing interface is `mdformat.plugins.ParserExtensionInterface.add_cli_argument_group`.
+- Added
+  - Plugin interface: `mdformat.plugins.ParserExtensionInterface.add_cli_argument_group`.
+    With this plugins can now read CLI arguments merged with values from `.mdformat.toml`.
+- Improved
+  - Plugin interface: A trailing newline is added to fenced code blocks if a plugin fails to add it.
+
 ## 0.7.18
 
 - Added

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -195,7 +195,17 @@ def make_arg_parser(
         )
     for plugin in parser_extensions.values():
         if hasattr(plugin, "add_cli_options"):
-            # TODO: deprecate in favor of add_cli_argument_group
+            import inspect
+            import warnings
+
+            warnings.warn_explicit(
+                "`mdformat.plugins.ParserExtensionInterface.add_cli_options`"
+                " is deprecated."
+                " Please use `add_cli_argument_group`.",
+                DeprecationWarning,
+                filename=inspect.getsourcefile(plugin),
+                lineno=inspect.getsourcelines(plugin)[1],
+            )
             plugin.add_cli_options(parser)
     for plugin_id, plugin in parser_extensions.items():
         if hasattr(plugin, "add_cli_argument_group"):

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -203,8 +203,8 @@ def make_arg_parser(
                 " is deprecated."
                 " Please use `add_cli_argument_group`.",
                 DeprecationWarning,
-                filename=inspect.getsourcefile(plugin),
-                lineno=inspect.getsourcelines(plugin)[1],
+                filename=str(inspect.getsourcefile(plugin)),  # type: ignore[arg-type]
+                lineno=inspect.getsourcelines(plugin)[1],  # type: ignore[arg-type]
             )
             plugin.add_cli_options(parser)
     for plugin_id, plugin in parser_extensions.items():

--- a/src/mdformat/_conf.py
+++ b/src/mdformat/_conf.py
@@ -11,6 +11,7 @@ DEFAULT_OPTS = {
     "number": False,
     "end_of_line": "lf",
     "exclude": [],
+    "plugin": {},
 }
 
 
@@ -65,6 +66,12 @@ def _validate_values(opts: Mapping, conf_path: Path) -> None:  # noqa: C901
         for pattern in opts["exclude"]:
             if not isinstance(pattern, str):
                 raise InvalidConfError(f"Invalid 'exclude' value in {conf_path}")
+    if "plugin" in opts:
+        if not isinstance(opts["plugin"], dict):
+            raise InvalidConfError(f"Invalid 'plugin' value in {conf_path}")
+        for plugin_conf in opts["plugin"].values():
+            if not isinstance(plugin_conf, dict):
+                raise InvalidConfError(f"Invalid 'plugin' value in {conf_path}")
 
 
 def _validate_keys(opts: Mapping, conf_path: Path) -> None:

--- a/src/mdformat/plugins.py
+++ b/src/mdformat/plugins.py
@@ -40,10 +40,26 @@ class ParserExtensionInterface(Protocol):
     # (optional)
     POSTPROCESSORS: Mapping[str, Postprocess]
 
+    # TODO: deprecate in favor of add_cli_argument_group
     @staticmethod
     def add_cli_options(parser: argparse.ArgumentParser) -> None:
         """Add options to the mdformat CLI, to be stored in
         mdit.options["mdformat"] (optional)"""
+
+    @staticmethod
+    def add_cli_argument_group(group: argparse._ArgumentGroup) -> None:
+        """Add an argument group to mdformat CLI and add arguments to it.
+
+        Call `group.add_argument()` to add CLI arguments (signature is
+        the same as argparse.ArgumentParser.add_argument). Values will be
+        stored in a mapping under mdit.options["mdformat"]["plugin"][<plugin_id>]
+        where <plugin_id> equals entry point name of the plugin.
+
+        The mapping will be merged with values read from TOML config file
+        section [plugin.<plugin_id>].
+
+        (optional)
+        """
 
     @staticmethod
     def update_mdit(mdit: MarkdownIt) -> None:

--- a/src/mdformat/plugins.py
+++ b/src/mdformat/plugins.py
@@ -42,7 +42,7 @@ class ParserExtensionInterface(Protocol):
 
     @staticmethod
     def add_cli_options(parser: argparse.ArgumentParser) -> None:
-        """DEPRECATED Use `add_cli_argument_group` instead.
+        """DEPRECATED - use `add_cli_argument_group` instead.
 
         Add options to the mdformat CLI, to be stored in
         mdit.options["mdformat"] (optional)

--- a/src/mdformat/plugins.py
+++ b/src/mdformat/plugins.py
@@ -40,11 +40,13 @@ class ParserExtensionInterface(Protocol):
     # (optional)
     POSTPROCESSORS: Mapping[str, Postprocess]
 
-    # TODO: deprecate in favor of add_cli_argument_group
     @staticmethod
     def add_cli_options(parser: argparse.ArgumentParser) -> None:
-        """Add options to the mdformat CLI, to be stored in
-        mdit.options["mdformat"] (optional)"""
+        """DEPRECATED Use `add_cli_argument_group` instead.
+
+        Add options to the mdformat CLI, to be stored in
+        mdit.options["mdformat"] (optional)
+        """
 
     @staticmethod
     def add_cli_argument_group(group: argparse._ArgumentGroup) -> None:

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -68,6 +68,8 @@ def test_invalid_toml(tmp_path, capsys):
         ("number", "number = 0"),
         ("exclude", "exclude = '**'"),
         ("exclude", "exclude = ['1',3]"),
+        ("plugin", "plugin = []"),
+        ("plugin", "plugin.gfm = {}\nplugin.myst = 1"),
     ],
 )
 def test_invalid_conf_value(bad_conf, conf_key, tmp_path, capsys):


### PR DESCRIPTION
Closes https://github.com/executablebooks/mdformat/issues/378

Add: `mdformat.plugins.ParserExtensionInterface.add_cli_argument_group`
Deprecate: `mdformat.plugins.ParserExtensionInterface.add_cli_options`