### PR TITLE
improve: Convert tabs to spaces. Reduce space sequences to one space

### DIFF
--- a/docs/users/changelog.md
+++ b/docs/users/changelog.md
@@ -14,6 +14,7 @@ Note that there is currently no guarantee for a stable Markdown formatting style
 - Changed
   - Style: No longer escape square bracket enclosures.
   - Style: No longer escape less than sign followed by space character.
+  - Style: Convert tabs to spaces. Reduce space sequences to one space.
 - Improved
   - Plugin interface: A trailing newline is added to fenced code blocks if a plugin fails to add it.
 

--- a/src/mdformat/renderer/_context.py
+++ b/src/mdformat/renderer/_context.py
@@ -111,6 +111,11 @@ def text(node: RenderTreeNode, context: RenderContext) -> str:
     """
     text = node.content
 
+    # Convert tabs to spaces
+    text = text.replace("\t", " ")
+    # Reduce tabs and spaces to one space
+    text = re.sub(" {2,}", " ", text)
+
     # Escape backslash to prevent it from making unintended escapes.
     # This escape has to be first, else we start multiplying backslashes.
     text = text.replace("\\", "\\\\")

--- a/tests/data/default_style.md
+++ b/tests/data/default_style.md
@@ -508,3 +508,25 @@ Less than sign escapes
 
 \<
 .
+
+Tabs to spaces
+.
+# Convert	tab	to	space	in			headings
+
+Make a space	here.
+.
+# Convert tab to space in headings
+
+Make a space here.
+.
+
+Reduce tabs and spaces to one space
+.
+# Reduce  		in			  	headings
+
+Reduce to a space	 	here.
+.
+# Reduce in headings
+
+Reduce to a space here.
+.


### PR DESCRIPTION
Helps with https://github.com/executablebooks/mdformat/issues/262 but has no effect on inline code yet.