### PR TITLE
maintain: remove broken tests from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include src/mdformat/py.typed
+prune tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0.0"]
+requires = ["setuptools>=69"]
 build-backend = "setuptools.build_meta"
 
 


### PR DESCRIPTION
Tests were silently (apparently a change in setuptools) added to sdist in mdformat 0.7.17, but aren't tested and won't work since test data is missing. Removing them.