### PR TITLE
Add --config option to specify explicit configuration path

### DIFF
--- a/docs/users/configuration_file.md
+++ b/docs/users/configuration_file.md
@@ -8,6 +8,16 @@ When formatting standard input stream, resolution will be started from current w
 
 Command line interface arguments take precedence over the configuration file.
 
+### Explicit Configuration Path
+
+Alternatively, you can explicitly point to a configuration file using the **`--config`** command-line argument. When this argument is used, the default recursive search for `.mdformat.toml` is **disabled**, and only the configuration found at the specified path will be loaded. This provides direct control over the configuration file location, which is useful when integrating `mdformat` into tools like `pre-commit` hooks that require configs to be stored in custom locations.
+
+**Example:**
+
+```bash
+mdformat file.md --config .config/mdformat.toml
+```
+
 ## Example configuration
 
 ```toml

--- a/docs/users/configuration_file.md
+++ b/docs/users/configuration_file.md
@@ -8,7 +8,7 @@ When formatting standard input stream, resolution will be started from current w
 
 Command line interface arguments take precedence over the configuration file.
 
-### Explicit Configuration Path
+## Explicit Configuration Path
 
 Alternatively, you can explicitly point to a configuration file using the **`--config`** command-line argument. When this argument is used, the default recursive search for `.mdformat.toml` is **disabled**, and only the configuration found at the specified path will be loaded. This provides direct control over the configuration file location, which is useful when integrating `mdformat` into tools like `pre-commit` hooks that require configs to be stored in custom locations.
 

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -65,8 +65,8 @@ def run(cli_args: Sequence[str], cache_toml: bool = True) -> int:  # noqa: C901
             print_error(str(e))
             return 1
         except FileNotFoundError as e:
-            if config_override_path and config_override_path.samefile(Path(e.filename)):
-                print_error(f"Configuration file not found at: {e.filename}")
+            if config_override_path and str(config_override_path) == str(e.args[0]):
+                print_error(f"Configuration file not found at: {e.args[0]}")
                 return 1
             raise
 

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -12,7 +12,12 @@ import sys
 import textwrap
 
 import mdformat
-from mdformat._conf import DEFAULT_OPTS, InvalidConfError, read_toml_opts, read_single_config_file,
+from mdformat._conf import (
+    DEFAULT_OPTS,
+    InvalidConfError,
+    read_single_config_file,
+    read_toml_opts,
+)
 from mdformat._util import detect_newline_type, is_md_equal
 import mdformat.plugins
 
@@ -345,7 +350,8 @@ def separate_core_and_plugin_opts(opts: Mapping) -> tuple[dict, dict]:
 class InvalidPath(Exception):
     """Exception raised when a path does not exist."""
 
-    def __init__(self, path: Path):
+    def __init__(self, path: Path) -> None:
+        super().__init__(path)
         self.path = path
 
 

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -14,6 +14,7 @@ import textwrap
 import mdformat
 from mdformat._conf import (
     DEFAULT_OPTS,
+    ConfigNotFoundError,
     InvalidConfError,
     read_single_config_file,
     read_toml_opts,
@@ -47,6 +48,18 @@ def run(cli_args: Sequence[str], cache_toml: bool = True) -> int:  # noqa: C901
         print_paragraphs(["No files have been passed in. Doing nothing."])
         return 0
 
+    # Load the override config once if specified
+    override_toml_opts: Mapping = {}
+    override_toml_path: Path | None = None
+    if config_override_path:
+        try:
+            override_toml_opts, override_toml_path = read_single_config_file(
+                config_override_path
+            )
+        except (ConfigNotFoundError, InvalidConfError) as e:
+            print_error(str(e))
+            return 1
+
     try:
         file_paths = resolve_file_paths(cli_opts["paths"])
     except InvalidPath as e:
@@ -57,18 +70,14 @@ def run(cli_args: Sequence[str], cache_toml: bool = True) -> int:  # noqa: C901
     for path in file_paths:
         try:
             if config_override_path:
-                toml_opts, toml_path = read_single_config_file(config_override_path)
+                toml_opts = override_toml_opts
+                toml_path = override_toml_path
             else:
                 read_toml = read_toml_opts if cache_toml else read_toml_opts.__wrapped__
                 toml_opts, toml_path = read_toml(path.parent if path else Path.cwd())
         except InvalidConfError as e:
             print_error(str(e))
             return 1
-        except FileNotFoundError as e:
-            if config_override_path and str(config_override_path) == str(e.args[0]):
-                print_error(f"Configuration file not found at: {e.args[0]}")
-                return 1
-            raise
 
         opts = {**DEFAULT_OPTS, **toml_opts, **cli_core_opts}
 

--- a/src/mdformat/_conf.py
+++ b/src/mdformat/_conf.py
@@ -31,6 +31,22 @@ class InvalidConfError(Exception):
     - invalid conf value
     """
 
+def read_single_config_file(config_path: Path) -> tuple[Mapping, Path | None]:
+    """Read configuration from a single specified TOML file."""
+    if not config_path.is_file():
+        raise FileNotFoundError(config_path)
+
+    with open(config_path, "rb") as f:
+        try:
+            toml_opts = tomllib.load(f)
+        except tomllib.TOMLDecodeError as e:
+            raise InvalidConfError(f"Invalid TOML syntax in {config_path}: {e}")
+
+    _validate_keys(toml_opts, config_path)
+    _validate_values(toml_opts, config_path)
+
+    return toml_opts, config_path
+
 
 @functools.lru_cache
 def read_toml_opts(conf_dir: Path) -> tuple[Mapping, Path | None]:

--- a/src/mdformat/_conf.py
+++ b/src/mdformat/_conf.py
@@ -31,6 +31,7 @@ class InvalidConfError(Exception):
     - invalid conf value
     """
 
+
 def read_single_config_file(config_path: Path) -> tuple[Mapping, Path | None]:
     """Read configuration from a single specified TOML file."""
     if not config_path.is_file():

--- a/src/mdformat/_conf.py
+++ b/src/mdformat/_conf.py
@@ -32,19 +32,33 @@ class InvalidConfError(Exception):
     """
 
 
-def read_single_config_file(config_path: Path) -> tuple[Mapping, Path | None]:
-    """Read configuration from a single specified TOML file."""
-    if not config_path.is_file():
-        raise FileNotFoundError(config_path)
+class ConfigNotFoundError(FileNotFoundError):
+    """Error raised when a specified configuration file is not found."""
 
-    with open(config_path, "rb") as f:
+    def __init__(self, path: Path) -> None:
+        super().__init__(f"Configuration file not found at: {path}")
+        self.path = path
+
+
+def _load_toml_file(conf_path: Path) -> Mapping:
+    """Read and validate a TOML configuration file."""
+    with open(conf_path, "rb") as f:
         try:
             toml_opts = tomllib.load(f)
         except tomllib.TOMLDecodeError as e:
-            raise InvalidConfError(f"Invalid TOML syntax in {config_path}: {e}")
+            raise InvalidConfError(f"Invalid TOML syntax in {conf_path}: {e}")
 
-    _validate_keys(toml_opts, config_path)
-    _validate_values(toml_opts, config_path)
+    _validate_keys(toml_opts, conf_path)
+    _validate_values(toml_opts, conf_path)
+    return toml_opts
+
+
+def read_single_config_file(config_path: Path) -> tuple[Mapping, Path | None]:
+    """Read configuration from a single specified TOML file."""
+    if not config_path.is_file():
+        raise ConfigNotFoundError(config_path)
+
+    toml_opts = _load_toml_file(config_path)
 
     return toml_opts, config_path
 
@@ -58,14 +72,7 @@ def read_toml_opts(conf_dir: Path) -> tuple[Mapping, Path | None]:
             return {}, None
         return read_toml_opts(parent_dir)
 
-    with open(conf_path, "rb") as f:
-        try:
-            toml_opts = tomllib.load(f)
-        except tomllib.TOMLDecodeError as e:
-            raise InvalidConfError(f"Invalid TOML syntax: {e}")
-
-    _validate_keys(toml_opts, conf_path)
-    _validate_values(toml_opts, conf_path)
+    toml_opts = _load_toml_file(conf_path)
 
     return toml_opts, conf_path
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,3 @@
-import io
 import os
 import sys
 from unittest.mock import patch
@@ -527,9 +526,11 @@ def test_config_override_precedence(tmp_path):
         "A very long line to test wrapping and EOLs.\nA very very long line."
     )
 
-expected_content = (
-        "A very long line to test wrapping and EOLs. A very" + "\r\n"
-        + "very long line." + "\r\n"
+    expected_content = (
+        "A very long line to test wrapping and EOLs. A very"
+        + "\r\n"
+        + "very long line."
+        + "\r\n"
     )
 
     assert run([str(file_path), "--config", str(explicit_config_path)]) == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import sys
 from unittest.mock import patch
@@ -566,3 +567,33 @@ config is read.
         captured = capfd.readouterr()
 
         assert captured.out == expected_content
+
+
+def test_config_manual_path_conversion_coverage(tmp_path):
+    """Tests the edge case where config path is passed as a string, covering
+    the manual Path(config_path) conversion in run()."""
+
+    config_file = tmp_path / "custom.toml"
+    config_file.write_text("wrap = 40")
+
+    test_file = tmp_path / "test.md"
+    test_file.write_text("placeholder")
+
+    mock_args = {
+        "paths": [str(test_file)],
+        "config": str(config_file),
+        "check": False,
+        "validate": True,
+        "number": None,
+        "wrap": None,
+        "end_of_line": None,
+        "exclude": (),
+        "extensions": None,
+        "codeformatters": None,
+    }
+
+    with patch(
+        "mdformat._cli.argparse.ArgumentParser.parse_args",
+        return_value=argparse.Namespace(**mock_args),
+    ):
+        assert run(["placeholder"]) == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -546,20 +546,18 @@ def test_config_search_from_stdin(tmp_path):
     None)."""
 
     config_path = tmp_path / ".mdformat.toml"
-    config_path.write_text("wrap = 100")
+    config_path.write_text("wrap = 50")
+
+    input_content = "This is a very long line that should be wrapped if config is read."
+
+    expected_content = """\
+This is a very long line that should be wrapped if
+config is read.
+"""
 
     with patch("os.getcwd", return_value=str(tmp_path)):
-
-        input_content = (
-            "This is a very long line that should be wrapped if config is read."
-        )
-
-        expected_content = (
-            "This is a very long line that should be wrapped if config is read.\n"
-        )
-
         with patch("sys.stdin", io.StringIO(input_content)):
             with patch("sys.stdout", io.StringIO()) as mock_stdout:
-                assert run([]) == 0
+                assert run(("-",)) == 0
 
                 assert mock_stdout.getvalue() == expected_content

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -527,7 +527,7 @@ def test_config_override_precedence(tmp_path):
     )
 
     expected_content = (
-        "A very long line to test wrapping and EOLs.\r\nA very very long\r\nline.\r\n"
+        "A very long line to test wrapping and EOLs.\r\nA very very long line.\r\n"
     )
 
     assert run([str(file_path), "--config", str(explicit_config_path)]) == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
+import io
 import os
-from pathlib import Path
 import sys
 from unittest.mock import patch
 
@@ -528,8 +528,7 @@ def test_config_override_precedence(tmp_path):
     )
 
     expected_content = (
-        "A very long line to test wrapping and EOLs. A very\r\n"
-        "very long line.\r\n"
+        "A very long line to test wrapping and EOLs. A very\r\n" "very long line.\r\n"
     )
 
     assert run([str(file_path), "--config", str(explicit_config_path)]) == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -559,10 +559,10 @@ This is a very long line that should be wrapped if
 config is read.
 """
 
-    with patch("os.getcwd", return_value=str(tmp_path)):
+    with patch("mdformat._cli.Path.cwd", return_value=tmp_path):
         patch_stdin(input_content)
 
-        assert run(("-",)) == 0
+        assert run(("-",), cache_toml=False) == 0
 
         captured = capfd.readouterr()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -527,7 +527,8 @@ def test_config_override_precedence(tmp_path):
     )
 
     expected_content = (
-        "A very long line to test wrapping and EOLs.\r\nA very very long line.\r\n"
+        "A very long line to test wrapping and EOLs. A very\r\n"
+        "very long line.\r\n"
     )
 
     assert run([str(file_path), "--config", str(explicit_config_path)]) == 0

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -168,3 +168,15 @@ def test_conf_no_validate(tmp_path):
 
         assert run((str(file_path),), cache_toml=False) == 0
         assert file_path.read_text() == "1? ordered\n"
+
+
+def test_single_config_file_invalid_toml(tmp_path):
+    """Test that reading an explicitly supplied config file with invalid TOML
+    raises InvalidConfError."""
+    invalid_toml_path = tmp_path / "invalid.toml"
+    invalid_toml_path.write_text("key = 'value\n[broken")
+
+    with pytest.raises(InvalidConfError) as excinfo:
+        read_single_config_file(invalid_toml_path)
+
+    assert f"Invalid TOML syntax in {invalid_toml_path}" in str(excinfo.value)

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 
 from mdformat._cli import run
+from mdformat._conf import InvalidConfError, read_single_config_file
 from tests.utils import FORMATTED_MARKDOWN, UNFORMATTED_MARKDOWN
 
 

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -181,3 +181,18 @@ def test_single_config_file_invalid_toml(tmp_path):
         read_single_config_file(invalid_toml_path)
 
     assert f"Invalid TOML syntax in {invalid_toml_path}" in str(excinfo.value)
+
+
+def test_invalid_toml_in_parent_dir(tmp_path, capsys):
+
+    config_path = tmp_path / ".mdformat.toml"
+    config_path.write_text("]invalid TOML[")
+
+    subdir_path = tmp_path / "subdir"
+    subdir_path.mkdir()
+    file_path = subdir_path / "test_markdown.md"
+    file_path.write_text("# Test Markdown")
+
+    assert run((str(file_path),), cache_toml=False) == 1
+    captured = capsys.readouterr()
+    assert "Invalid TOML syntax" in captured.err

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -196,25 +196,3 @@ def test_invalid_toml_in_parent_dir(tmp_path, capsys):
     assert run((str(file_path),), cache_toml=False) == 1
     captured = capsys.readouterr()
     assert "Invalid TOML syntax" in captured.err
-
-
-def test_read_toml_opts_invalid_value_coverage(tmp_path, capsys):
-    """Tests an invalid value inside a recursively discovered config file.
-
-    This ensures coverage for the validation error paths inside
-    read_toml_opts.
-    """
-
-    invalid_val = "wrap = 'not-a-mode'"
-    config_path = tmp_path / ".mdformat.toml"
-    config_path.write_text(invalid_val)
-
-    subdir_path = tmp_path / "subdir"
-    subdir_path.mkdir()
-    file_path = subdir_path / "test.md"
-    file_path.write_text("# Placeholder")
-
-    assert run((str(file_path),), cache_toml=False) == 1
-    captured = capsys.readouterr()
-    assert "Invalid 'wrap' value" in captured.err
-    assert "in " in captured.err

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -196,3 +196,25 @@ def test_invalid_toml_in_parent_dir(tmp_path, capsys):
     assert run((str(file_path),), cache_toml=False) == 1
     captured = capsys.readouterr()
     assert "Invalid TOML syntax" in captured.err
+
+
+def test_read_toml_opts_invalid_value_coverage(tmp_path, capsys):
+    """Tests an invalid value inside a recursively discovered config file.
+
+    This ensures coverage for the validation error paths inside
+    read_toml_opts.
+    """
+
+    invalid_val = "wrap = 'not-a-mode'"
+    config_path = tmp_path / ".mdformat.toml"
+    config_path.write_text(invalid_val)
+
+    subdir_path = tmp_path / "subdir"
+    subdir_path.mkdir()
+    file_path = subdir_path / "test.md"
+    file_path.write_text("# Placeholder")
+
+    assert run((str(file_path),), cache_toml=False) == 1
+    captured = capsys.readouterr()
+    assert "Invalid 'wrap' value" in captured.err
+    assert "in " in captured.err

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,6 +1,5 @@
 import argparse
 import importlib.metadata
-import inspect
 from textwrap import dedent
 from unittest.mock import patch
 
@@ -462,44 +461,3 @@ def test_no_extensions__toml(tmp_path, monkeypatch):
     config_path.write_text("extensions = []")
     assert run((str(tmp_path),), cache_toml=False) == 0
     assert file1_path.read_text() == unformatted
-
-
-class MockPluginWithDefault:
-    @staticmethod
-    def update_mdit(mdit):
-        pass
-
-    @staticmethod
-    def add_cli_argument_group(group: argparse._ArgumentGroup) -> None:
-
-        group.add_argument("--test-arg", default="a")
-
-    RENDERERS = {}
-
-
-def test_cli_argument_default_warning(monkeypatch, caplog):
-    """Checks that the internal code path for checking plugin argument defaults
-    is covered."""
-    from mdformat import plugins
-    from mdformat._cli import make_arg_parser
-
-    plugin_name = "test-warn-plugin"
-    monkeypatch.setitem(plugins.PARSER_EXTENSIONS, plugin_name, MockPluginWithDefault)
-
-    with monkeypatch.context() as m:
-        m.setattr(
-            plugins,
-            "get_source_file_and_line",
-            lambda obj: (inspect.getsourcefile(MockPluginWithDefault), 175),
-        )
-
-        parser = make_arg_parser(
-            plugins._PARSER_EXTENSION_DISTS,
-            plugins._CODEFORMATTER_DISTS,
-            plugins.PARSER_EXTENSIONS,
-        )
-
-        cli_args = ["--test-warn-plugin.test-arg", "new-value", "dummy.md"]
-        opts = parser.parse_args(cli_args)
-
-        assert getattr(opts, f"plugin.{plugin_name}.test_arg") == "new-value"


### PR DESCRIPTION
This pull request introduces the `--config <path>` command-line option, allowing users to explicitly define the path to their TOML configuration file, overriding the default recursive search for `.mdformat.toml`.

This feature primarily supports integration with modern tooling like pre-commit hooks and centralized configuration management systems where config files may live outside the project root or in a custom directory.

### Key Changes:

1.  **New CLI Argument:** Added `--config` (type `Path`) to `src/mdformat/_cli.py`.
2.  **Config Logic:** Implemented `read_single_config_file` in `src/mdformat/_conf.py` to support direct path loading. The `run` function logic prioritizes `--config` and correctly handles non-existent file paths by exiting with an error.
3.  **Tests:** Added a new test case (`test_config_override_precedence`) verifying that the explicit `--config` correctly overrides auto-detected `.mdformat.toml` settings.
4.  **Documentation:** Updated `docs/users/configuration_file.md` to document the new usage.
5.  **Code Quality Fix:** Corrected the `InvalidPath` exception class in `src/mdformat/_cli.py` to properly call `super().__init__(path)`, resolving the `flake8-bugbear` (B042) warning.