### PR TITLE
Add a copy button to code blocks in the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ release = '1.0.0'  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['myst_parser']
+extensions = ['myst_parser', 'sphinx_copybutton']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ docutils == 0.21.2
 sphinx == 8.2.3
 myst-parser == 4.0.1
 furo == 2025.7.19
+sphinx-copybutton==0.5.2


### PR DESCRIPTION
Feel free to close if you don't want this for any reason, but this adds a small button to copy code blocks.

I noticed this while finding out how to add this as a pre-commit hook.

<img width="761" height="302" alt="Screenshot 2026-03-11 at 2 09 53 p m" src="https://github.com/user-attachments/assets/054d3ecb-7c15-4d69-8bfb-7c765f40d78d" />
