### PR TITLE
fix: merge CLI --exclude patterns with .mdformat.toml exclude

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,8 @@ repos:
   rev: ab802050e6e96aaaf7f917fcbc333bb74e2e57f7  # frozen: v1.4.2
   hooks:
   - id: docformatter
+    # v1.4.2 setup.py breaks on Python 3.14 (removed ast.Constant.s alias)
+    language_version: python3.13
 - repo: https://github.com/PyCQA/flake8
   rev: d93590f5be797aabb60e3b09f2f52dddb02f349f  # frozen: 7.3.0
   hooks:

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -330,6 +330,7 @@ class InvalidPath(Exception):
     """Exception raised when a path does not exist."""
 
     def __init__(self, path: Path):
+        super().__init__(path)
         self.path = path
 
 

--- a/src/mdformat/_cli.py
+++ b/src/mdformat/_cli.py
@@ -65,7 +65,10 @@ def run(cli_args: Sequence[str], cache_toml: bool = True) -> int:  # noqa: C901
                 opts["plugin"][plugin_id] = plugin_opts
 
         if sys.version_info >= (3, 13):  # pragma: >=3.13 cover
-            if is_excluded(path, opts["exclude"], toml_path, "exclude" in cli_opts):
+            # TOML patterns are rooted at the config dir, CLI patterns at cwd.
+            toml_excludes = toml_opts.get("exclude", ())
+            cli_excludes = cli_core_opts.get("exclude", ())
+            if is_excluded(path, toml_excludes, cli_excludes, toml_path):
                 continue
         else:  # pragma: <3.13 cover
             if "exclude" in toml_opts:
@@ -358,23 +361,28 @@ def resolve_file_paths(path_strings: Iterable[str]) -> list[None | Path]:
 
 def is_excluded(  # pragma: >=3.13 cover
     path: Path | None,
-    patterns: list[str],
+    toml_patterns: Iterable[str],
+    cli_patterns: Iterable[str],
     toml_path: Path | None,
-    excludes_from_cli: bool,
 ) -> bool:
     if not path:
         return False
 
-    if not excludes_from_cli and toml_path:
-        exclude_root = toml_path.parent
-    else:
-        exclude_root = Path.cwd()
+    toml_root = toml_path.parent if toml_path else None
+    if _matches_patterns(path, toml_patterns, toml_root):
+        return True
+    return _matches_patterns(path, cli_patterns, Path.cwd())
 
+
+def _matches_patterns(  # pragma: >=3.13 cover
+    path: Path, patterns: Iterable[str], root: Path | None
+) -> bool:
+    if root is None:
+        return False
     try:
-        relative_path = path.relative_to(exclude_root)
+        relative_path = path.relative_to(root)
     except ValueError:
         return False
-
     return any(relative_path.full_match(pattern) for pattern in patterns)
 
 

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -140,6 +140,27 @@ def test_exclude(tmp_path, capsys):
 @pytest.mark.skipif(
     sys.version_info < (3, 13), reason="'exclude' only possible on 3.13+"
 )
+def test_exclude_cli_and_toml_merge(tmp_path):
+    config_path = tmp_path / ".mdformat.toml"
+    config_path.write_text("exclude = ['file1.md']")
+
+    file1_path = tmp_path / "file1.md"
+    file2_path = tmp_path / "file2.md"
+    file3_path = tmp_path / "file3.md"
+    file1_path.write_text(UNFORMATTED_MARKDOWN)
+    file2_path.write_text(UNFORMATTED_MARKDOWN)
+    file3_path.write_text(UNFORMATTED_MARKDOWN)
+
+    with mock.patch("mdformat._cli.Path.cwd", return_value=tmp_path):
+        assert run((str(tmp_path), "--exclude", "file2.md")) == 0
+    assert file1_path.read_text() == UNFORMATTED_MARKDOWN
+    assert file2_path.read_text() == UNFORMATTED_MARKDOWN
+    assert file3_path.read_text() == FORMATTED_MARKDOWN
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 13), reason="'exclude' only possible on 3.13+"
+)
 def test_empty_exclude(tmp_path, capsys):
     config_path = tmp_path / ".mdformat.toml"
     config_path.write_text("exclude = []")


### PR DESCRIPTION
CLI `--exclude` patterns are now additive with the `.mdformat.toml` `exclude` list instead of replacing it; TOML patterns stay rooted at the config dir and CLI patterns at the cwd, and a path is skipped if either set matches. Closes #575.