### PR TITLE
Fix error on emphasis around whitespace character reference (#492)

### DIFF
--- a/docs/users/changelog.md
+++ b/docs/users/changelog.md
@@ -18,6 +18,9 @@ Note that there is currently no guarantee for a stable Markdown formatting style
 - Fixed
   - Read UTF-8 from standard input on all systems.
     Thank you, [Christopher Prohm](https://github.com/chmp), for the PR.
+  - No longer error on emphasis whose content is a whitespace character
+    reference (e.g. `*&#32;*`). The boundary whitespace is now kept in
+    character reference form so the emphasis markers remain functional.
 
 ## 0.7.22
 

--- a/src/mdformat/renderer/_context.py
+++ b/src/mdformat/renderer/_context.py
@@ -289,12 +289,22 @@ def link(node: RenderTreeNode, context: RenderContext) -> str:
 
 def em(node: RenderTreeNode, context: RenderContext) -> str:
     text = make_render_children(separator="")(node, context)
+    # Emphasis can not begin or end in Unicode whitespace, so if it does
+    # (e.g. the whitespace came from a character reference like `&#32;`),
+    # re-decimalify the boundary whitespace to keep the markers functional.
+    text = decimalify_leading(codepoints.UNICODE_WHITESPACE, text)
+    text = decimalify_trailing(codepoints.UNICODE_WHITESPACE, text)
     indicator = node.markup
     return indicator + text + indicator
 
 
 def strong(node: RenderTreeNode, context: RenderContext) -> str:
     text = make_render_children(separator="")(node, context)
+    # Emphasis can not begin or end in Unicode whitespace, so if it does
+    # (e.g. the whitespace came from a character reference like `&#32;`),
+    # re-decimalify the boundary whitespace to keep the markers functional.
+    text = decimalify_leading(codepoints.UNICODE_WHITESPACE, text)
+    text = decimalify_trailing(codepoints.UNICODE_WHITESPACE, text)
     indicator = node.markup
     return indicator + text + indicator
 

--- a/tests/data/default_style.md
+++ b/tests/data/default_style.md
@@ -530,3 +530,17 @@ Reduce to a space	 	here.
 
 Reduce to a space here.
 .
+
+emphasis around whitespace character reference (issue 492)
+.
+*&#32;*
+.
+*&#32;*
+.
+
+strong emphasis around named whitespace character reference
+.
+**&nbsp;**
+.
+**&#160;**
+.


### PR DESCRIPTION
Fixes #492

## Root cause

For emphasis whose content is a whitespace character reference, e.g.

```markdown
*&#32;*
```

markdown-it decodes the reference to literal whitespace in the text token's
`content` (`" "`), keeping the original source only in the token's `markup`
field. The `em`/`strong` renderers emitted that literal whitespace directly
between the emphasis markers, producing `* *`. On re-parse, a
Unicode-whitespace flanking character can no longer open or close emphasis
(CommonMark emphasis rules), so the formatted Markdown renders to different
HTML than the input and the AST safety check aborts with an error.

## Reproduction

On the pristine `master` clone (mdformat 1.0.0):

```console
$ printf -- '*&#32;*' | mdformat -
Error: Could not format "-".

Formatted Markdown renders to different HTML than input Markdown. This is a bug
in mdformat or one of its installed plugins. ...
```

Internally (validation disabled) mdformat produced `\* *`, whereas:

- input `*&#32;*` renders to `<p><em> </em></p>`
- output `\* *` / `* *` renders to `<p>* *</p>` (no emphasis) — hence the mismatch.

With the fix:

```console
$ printf -- '*&#32;*' | mdformat -
*&#32;*
$ printf -- '*&nbsp;*' | mdformat -
*&#160;*
```

Both round-trip to the same HTML as the input.

## Fix

In `em()` and `strong()` (`src/mdformat/renderer/_context.py`), re-decimalify
leading/trailing Unicode whitespace of the rendered inner text using the
existing `decimalify_leading` / `decimalify_trailing` helpers. This mirrors
exactly what `paragraph()` already does for whitespace at paragraph
boundaries, so boundary whitespace is kept in character-reference form and the
emphasis markers stay functional. The change is localized to the two emphasis
renderers; non-whitespace content is untouched.

## Tests

Added two round-trip cases to `tests/data/default_style.md` (driven by
`tests/test_style.py`, which runs the real CLI including the AST check):

- `*&#32;*` → `*&#32;*`
- `**&nbsp;**` → `**&#160;**`

Confirmed these fail on unmodified code (the CLI exits non-zero via the AST
check) and pass with the fix. The full test suite passes locally
(`4286 passed, 1 skipped`), including all CommonMark spec fixtures, and
`black` / `isort` / `flake8` report no issues on the changed file.

Disclosure: prepared with AI assistance; reviewed and verified locally.
